### PR TITLE
Add cross-platform JDK 8 download support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## CN1 MCP
-Basic MCP optimized for Linux at this time.
+MCP server that now bundles Linux JDK 8 resources and can automatically download matching Temurin builds for macOS and Windows.
 
 It can run in two modes:
 

--- a/src/main/java/com/codename1/server/mcp/config/Cn1Config.java
+++ b/src/main/java/com/codename1/server/mcp/config/Cn1Config.java
@@ -17,6 +17,6 @@ public class Cn1Config {
 
     @ConfigurationProperties(prefix = "cn1")
     public record Cn1Props(String cacheDir, String libsVersionTag, Jdk8Props jdk8) {
-        public record Jdk8Props(String resourcePath, String rootMarker) {}
+        public record Jdk8Props(String linuxResourcePath, String macUrl, String windowsUrl, String rootMarker) {}
     }
 }

--- a/src/main/java/com/codename1/server/mcp/tools/GlobalExtractor.java
+++ b/src/main/java/com/codename1/server/mcp/tools/GlobalExtractor.java
@@ -5,14 +5,18 @@ import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
 import org.apache.commons.compress.compressors.gzip.GzipCompressorInputStream;
 
 import java.io.*;
+import java.net.URL;
 import java.nio.channels.FileChannel;
 import java.nio.channels.FileLock;
 import java.nio.file.*;
 import java.security.MessageDigest;
+import java.util.Comparator;
 import java.util.HexFormat;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
 
 public class GlobalExtractor {
     private static final ConcurrentHashMap<String, ReentrantLock> LOCAL_LOCKS = new ConcurrentHashMap<>();
@@ -62,7 +66,18 @@ public class GlobalExtractor {
 
     public Path ensureArchiveExtracted(String archiveResourcePath, String folderName) throws IOException {
         byte[] bytes = readResource(archiveResourcePath);
-        String hash = sha256(bytes).substring(0, 12);
+        ArchiveType type = ArchiveType.fromName(archiveResourcePath);
+        String identifier = archiveResourcePath + ":" + sha256(bytes);
+        return ensureArchiveExtracted(identifier, type, () -> new ByteArrayInputStream(bytes), folderName);
+    }
+
+    public Path ensureArchiveExtractedFromUrl(String url, String folderName) throws IOException {
+        ArchiveType type = ArchiveType.fromName(url);
+        return ensureArchiveExtracted("url:" + url, type, () -> openUrl(url), folderName);
+    }
+
+    private Path ensureArchiveExtracted(String identifier, ArchiveType type, IOSupplier<InputStream> supplier, String folderName) throws IOException {
+        String hash = sha256(identifier).substring(0, 12);
 
         Path parent = cacheDir.resolve("jdks").resolve(versionTag + "-" + hash);
         Path destRoot = parent.resolve(folderName);
@@ -76,32 +91,127 @@ public class GlobalExtractor {
              FileLock ignored = ch.lock()) {
             if (Files.exists(destRoot)) return destRoot;
 
-            Path tmpRoot = Files.createTempDirectory(parent, "tmp-extract-");
-            try (InputStream in = new ByteArrayInputStream(bytes);
-                 GzipCompressorInputStream gzi = new GzipCompressorInputStream(in);
-                 TarArchiveInputStream tar = new TarArchiveInputStream(gzi)) {
+            Files.createDirectories(parent);
 
-                TarArchiveEntry e;
-                while ((e = tar.getNextTarEntry()) != null) {
-                    Path out = tmpRoot.resolve(e.getName()).normalize();
-                    if (!out.startsWith(tmpRoot)) throw new IOException("Zip Slip detected: " + out);
-                    if (e.isDirectory()) {
-                        Files.createDirectories(out);
-                    } else {
-                        Files.createDirectories(out.getParent());
-                        try (OutputStream os = Files.newOutputStream(out)) {
-                            tar.transferTo(os);
-                        }
-                        if ((e.getMode() & 0100) != 0) out.toFile().setExecutable(true);
-                    }
+            Path archivePath = parent.resolve("archive" + type.extension);
+            if (!Files.exists(archivePath)) {
+                Path tmpArchive = Files.createTempFile(parent, "download-", type.extension);
+                try (InputStream in = supplier.get();
+                     OutputStream out = Files.newOutputStream(tmpArchive, StandardOpenOption.TRUNCATE_EXISTING)) {
+                    if (in == null) throw new IOException("Archive supplier returned null stream for " + identifier);
+                    in.transferTo(out);
+                }
+                Files.move(tmpArchive, archivePath, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+            }
+
+            Path tmpRoot = Files.createTempDirectory(parent, "tmp-extract-");
+            boolean success = false;
+            try {
+                extractArchive(archivePath, type, tmpRoot);
+                Files.move(tmpRoot, destRoot, StandardCopyOption.ATOMIC_MOVE);
+                success = true;
+            } finally {
+                if (!success) {
+                    cleanupDirectory(tmpRoot);
                 }
             }
-            Files.createDirectories(parent);
-            Files.move(tmpRoot, destRoot, StandardCopyOption.ATOMIC_MOVE);
         } finally {
             local.unlock();
         }
         return destRoot;
+    }
+
+    private void extractArchive(Path archivePath, ArchiveType type, Path destRoot) throws IOException {
+        switch (type) {
+            case TAR_GZ -> extractTarGz(archivePath, destRoot);
+            case ZIP -> extractZip(archivePath, destRoot);
+        }
+    }
+
+    private void extractTarGz(Path archivePath, Path destRoot) throws IOException {
+        try (InputStream in = Files.newInputStream(archivePath);
+             GzipCompressorInputStream gzi = new GzipCompressorInputStream(in);
+             TarArchiveInputStream tar = new TarArchiveInputStream(gzi)) {
+
+            TarArchiveEntry e;
+            while ((e = tar.getNextTarEntry()) != null) {
+                Path out = destRoot.resolve(e.getName()).normalize();
+                if (!out.startsWith(destRoot)) throw new IOException("Zip Slip detected: " + out);
+                if (e.isDirectory()) {
+                    Files.createDirectories(out);
+                } else {
+                    Files.createDirectories(out.getParent());
+                    try (OutputStream os = Files.newOutputStream(out)) {
+                        tar.transferTo(os);
+                    }
+                    if ((e.getMode() & 0100) != 0) out.toFile().setExecutable(true);
+                }
+            }
+        }
+    }
+
+    private void extractZip(Path archivePath, Path destRoot) throws IOException {
+        try (InputStream in = Files.newInputStream(archivePath);
+             ZipInputStream zip = new ZipInputStream(in)) {
+            ZipEntry entry;
+            while ((entry = zip.getNextEntry()) != null) {
+                Path out = destRoot.resolve(entry.getName()).normalize();
+                if (!out.startsWith(destRoot)) throw new IOException("Zip Slip detected: " + out);
+                if (entry.isDirectory()) {
+                    Files.createDirectories(out);
+                } else {
+                    Files.createDirectories(out.getParent());
+                    try (OutputStream os = Files.newOutputStream(out)) {
+                        zip.transferTo(os);
+                    }
+                    if (isExecutable(entry)) out.toFile().setExecutable(true);
+                }
+            }
+        }
+    }
+
+    private static boolean isExecutable(ZipEntry entry) {
+        // upper 16 bits of external attributes hold UNIX permissions when present
+        return ((entry.getExternalAttributes() >> 16) & 0100) != 0;
+    }
+
+    private void cleanupDirectory(Path dir) {
+        if (dir == null || !Files.exists(dir)) return;
+        try {
+            Files.walk(dir)
+                    .sorted(Comparator.reverseOrder())
+                    .forEach(path -> {
+                        try { Files.deleteIfExists(path); } catch (IOException ignored) {}
+                    });
+        } catch (IOException ignored) {
+        }
+    }
+
+    private InputStream openUrl(String url) throws IOException {
+        return new URL(url).openStream();
+    }
+
+    public enum ArchiveType {
+        TAR_GZ(".tar.gz"),
+        ZIP(".zip");
+
+        private final String extension;
+
+        ArchiveType(String extension) {
+            this.extension = extension;
+        }
+
+        static ArchiveType fromName(String name) {
+            String lower = name.toLowerCase();
+            if (lower.endsWith(".tar.gz") || lower.endsWith(".tgz")) return TAR_GZ;
+            if (lower.endsWith(".zip")) return ZIP;
+            throw new IllegalArgumentException("Unsupported archive type: " + name);
+        }
+    }
+
+    @FunctionalInterface
+    private interface IOSupplier<T> {
+        T get() throws IOException;
     }
 
     private static String sha256(byte[] d) {

--- a/src/main/java/com/codename1/server/mcp/tools/GlobalExtractor.java
+++ b/src/main/java/com/codename1/server/mcp/tools/GlobalExtractor.java
@@ -214,6 +214,9 @@ public class GlobalExtractor {
         T get() throws IOException;
     }
 
+    private static String sha256(String s) {
+        return sha256(s.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    }
     private static String sha256(byte[] d) {
         try {
             MessageDigest md = MessageDigest.getInstance("SHA-256");

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,7 @@
 spring.application.name=mcp
-cn1.cacheDir= ${user.home}/.cn1-mcp
+cn1.cacheDir=${user.home}/.cn1-mcp
 cn1.libsVersionTag=v1
-cn1.jdk8.resourcePath=/cn1libs/OpenJDK8U-jdk_x64_linux_hotspot_8u462b08.tar.gz
+cn1.jdk8.linuxResourcePath=/cn1libs/OpenJDK8U-jdk_x64_linux_hotspot_8u462b08.tar.gz
+cn1.jdk8.macUrl=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jdk_x64_mac_hotspot_8u382b05.tar.gz
+cn1.jdk8.windowsUrl=https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jdk_x64_windows_hotspot_8u382b05.zip
 cn1.jdk8.rootMarker=release

--- a/src/test/java/com/codename1/server/mcp/service/CompileIntegrationTest.java
+++ b/src/test/java/com/codename1/server/mcp/service/CompileIntegrationTest.java
@@ -28,7 +28,10 @@ public class CompileIntegrationTest {
         assumeTrue(resourceExists("/cn1libs/CodenameOne.jar"),
                 "Missing bundled CodenameOne.jar under /cn1libs/");
         jdkMgr = new Jdk8ManagerFromResource(extractor,
-                "/cn1libs/OpenJDK8U-jdk_x64_linux_hotspot_8u462b08.tar.gz", "release");
+                "/cn1libs/OpenJDK8U-jdk_x64_linux_hotspot_8u462b08.tar.gz",
+                "",
+                "",
+                "release");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- allow the JDK manager to download Temurin archives for Windows and macOS while still using the bundled Linux tarball
- extend the global extractor so it can cache and extract tar.gz or zip archives from either resources or remote URLs
- document the broader OS support and update configuration properties and tests accordingly

## Testing
- ./mvnw -q test *(fails: release version 25 not supported in container JDK)*

------
https://chatgpt.com/codex/tasks/task_e_68e4eb244ba48331b792eddec291b8a1