### PR TITLE
Ensure stdio logging uses file backend and add MCP test

### DIFF
--- a/.github/workflows/mcp-stdio-ci.yml
+++ b/.github/workflows/mcp-stdio-ci.yml
@@ -1,0 +1,25 @@
+name: MCP STDIO CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '25'
+          cache: maven
+
+      - name: Build and test in STDIO mode
+        env:
+          SPRING_PROFILES_ACTIVE: stdio
+        run: ./mvnw -B verify

--- a/src/main/java/com/codename1/server/mcp/McpApplication.java
+++ b/src/main/java/com/codename1/server/mcp/McpApplication.java
@@ -1,13 +1,19 @@
 package com.codename1.server.mcp;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class McpApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(McpApplication.class, args);
-	}
+        private static final Logger LOG = LoggerFactory.getLogger(McpApplication.class);
+
+        public static void main(String[] args) {
+                LOG.info("Starting Codename One MCP application with {} argument(s)", args.length);
+                SpringApplication.run(McpApplication.class, args);
+                LOG.info("Codename One MCP application started");
+        }
 
 }

--- a/src/main/java/com/codename1/server/mcp/config/Cn1Config.java
+++ b/src/main/java/com/codename1/server/mcp/config/Cn1Config.java
@@ -1,6 +1,8 @@
 package com.codename1.server.mcp.config;
 
 import com.codename1.server.mcp.tools.GlobalExtractor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
@@ -9,9 +11,11 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @EnableConfigurationProperties(Cn1Config.Cn1Props.class)
 public class Cn1Config {
+    private static final Logger LOG = LoggerFactory.getLogger(Cn1Config.class);
 
     @Bean
     public GlobalExtractor globalExtractor(Cn1Props p) {
+        LOG.info("Configuring GlobalExtractor with cacheDir={} and versionTag={}", p.cacheDir(), p.libsVersionTag());
         return new GlobalExtractor(p.cacheDir(), p.libsVersionTag());
     }
 

--- a/src/main/java/com/codename1/server/mcp/controller/McpSseController.java
+++ b/src/main/java/com/codename1/server/mcp/controller/McpSseController.java
@@ -1,6 +1,8 @@
 package com.codename1.server.mcp.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,10 +16,12 @@ import java.util.Map;
 @RestController
 @RequestMapping("/mcp")
 public class McpSseController {
+    private static final Logger LOG = LoggerFactory.getLogger(McpSseController.class);
     private final ObjectMapper mapper = new ObjectMapper();
 
     @GetMapping(produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     public SseEmitter connect() {
+        LOG.info("Received SSE connection request");
         SseEmitter emitter = new SseEmitter(0L); // never timeout
         // send a greeting / capabilities event
         try {
@@ -31,7 +35,12 @@ public class McpSseController {
                                     Map.of("name","cn1_compile_check","description","Verify code compiles in Codename One","input_schema",Map.of("type","object","properties",Map.of("files",Map.of("type","array"))))
                             ))
                     ))));
-        } catch (IOException e) { emitter.completeWithError(e); }
+        } catch (IOException e) {
+            LOG.error("Failed to send initial SSE payload", e);
+            emitter.completeWithError(e);
+        }
+        emitter.onCompletion(() -> LOG.info("SSE connection completed"));
+        emitter.onTimeout(() -> LOG.warn("SSE connection timed out"));
         return emitter;
     }
 }

--- a/src/main/java/com/codename1/server/mcp/controller/ToolsController.java
+++ b/src/main/java/com/codename1/server/mcp/controller/ToolsController.java
@@ -17,12 +17,15 @@ import com.codename1.server.mcp.service.ExternalCompileService;
 import com.codename1.server.mcp.service.LintService;
 import com.codename1.server.mcp.service.ScaffoldService;
 import com.codename1.server.mcp.service.SnippetService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/tools")
 public class ToolsController {
+    private static final Logger LOG = LoggerFactory.getLogger(ToolsController.class);
     private final LintService lint;
     private final ExternalCompileService compile;
     private final ScaffoldService scaffold;
@@ -36,23 +39,47 @@ public class ToolsController {
     }
 
     @PostMapping(value="/cn1_lint_code", consumes=MediaType.APPLICATION_JSON_VALUE)
-    public LintResponse lint(@RequestBody LintRequest req) { return lint.lint(req); }
+    public LintResponse lint(@RequestBody LintRequest req) {
+        LOG.info("HTTP lint request received: language={}, codeLength={}", req.language(), req.code() != null ? req.code().length() : 0);
+        LintResponse res = lint.lint(req);
+        LOG.debug("Lint response ok={}, diagnostics={}, quickFixes={}", res.ok(), res.diagnostics().size(), res.quickFixes().size());
+        return res;
+    }
 
     @PostMapping(value="/cn1_compile_check", consumes=MediaType.APPLICATION_JSON_VALUE)
-    public CompileResponse compile(@RequestBody CompileRequest req) { return compile.compile(req); }
+    public CompileResponse compile(@RequestBody CompileRequest req) {
+        LOG.info("HTTP compile request received with {} file(s)", req.files() != null ? req.files().size() : 0);
+        CompileResponse res = compile.compile(req);
+        LOG.debug("Compile response ok={}, outputLength={}", res.ok(), res.javacOutput() != null ? res.javacOutput().length() : 0);
+        return res;
+    }
 
     @PostMapping(value="/cn1_scaffold_project", consumes=MediaType.APPLICATION_JSON_VALUE)
-    public ScaffoldResponse scaffold(@RequestBody ScaffoldRequest req) { return scaffold.scaffold(req); }
+    public ScaffoldResponse scaffold(@RequestBody ScaffoldRequest req) {
+        LOG.info("HTTP scaffold request received: pkg={}, name={}", req.pkg(), req.name());
+        ScaffoldResponse res = scaffold.scaffold(req);
+        LOG.debug("Scaffold response contains {} file(s)", res.files().size());
+        return res;
+    }
 
     @PostMapping(value="/cn1_explain_violation", consumes=MediaType.APPLICATION_JSON_VALUE)
-    public ExplainResponse explain(@RequestBody ExplainRequest req) { return snippets.explain(req.ruleId()); }
+    public ExplainResponse explain(@RequestBody ExplainRequest req) {
+        LOG.info("HTTP explain request received for rule {}", req.ruleId());
+        return snippets.explain(req.ruleId());
+    }
 
     @PostMapping(value="/cn1_search_snippets", consumes=MediaType.APPLICATION_JSON_VALUE)
-    public SnippetsResponse snippets(@RequestBody SnippetsRequest req) { return snippets.get(req.topic()); }
+    public SnippetsResponse snippets(@RequestBody SnippetsRequest req) {
+        LOG.info("HTTP snippets request received for topic {}", req.topic());
+        SnippetsResponse response = snippets.get(req.topic());
+        LOG.debug("Returned {} snippet(s) for topic {}", response.snippets().size(), req.topic());
+        return response;
+    }
 
     // Auto-fix can be naive: rewrap UI mutations; expand as needed
     @PostMapping(value="/cn1_auto_fix", consumes=MediaType.APPLICATION_JSON_VALUE)
     public AutoFixResponse autoFix(@RequestBody AutoFixRequest req) {
+        LOG.info("HTTP auto-fix request received");
         String patched = req.code().replace("form.show();",
                 "com.codename1.ui.Display.getInstance().callSerially(() -> { form.show(); });");
         var patch = new Patch("Wrap show() in EDT", """
@@ -60,6 +87,8 @@ public class ToolsController {
       - form.show();
       + com.codename1.ui.Display.getInstance().callSerially(() -> { form.show(); });
       """);
-        return new AutoFixResponse(patched, java.util.List.of(patch));
+        AutoFixResponse res = new AutoFixResponse(patched, java.util.List.of(patch));
+        LOG.debug("Auto-fix generated {} patch(es)", res.patches().size());
+        return res;
     }
 }

--- a/src/main/java/com/codename1/server/mcp/service/ExternalCompileService.java
+++ b/src/main/java/com/codename1/server/mcp/service/ExternalCompileService.java
@@ -2,8 +2,11 @@ package com.codename1.server.mcp.service;
 
 import com.codename1.server.mcp.dto.CompileRequest;
 import com.codename1.server.mcp.dto.CompileResponse;
+import com.codename1.server.mcp.dto.FileEntry;
 import com.codename1.server.mcp.tools.GlobalExtractor;
 import com.codename1.server.mcp.tools.Jdk8ManagerFromResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.io.InputStream;
@@ -13,6 +16,7 @@ import java.util.*;
 
 @Service
 public class ExternalCompileService {
+    private static final Logger LOG = LoggerFactory.getLogger(ExternalCompileService.class);
     private final GlobalExtractor extractor;
     private final Jdk8ManagerFromResource jdk8;
 
@@ -23,21 +27,28 @@ public class ExternalCompileService {
 
     public CompileResponse compile(CompileRequest req) {
         try {
+            List<FileEntry> files =
+                    req.files() != null ? req.files() : List.of();
+            LOG.info("Compile request received with {} file(s)", files.size());
             // Extract libs once
             Path cn1   = extractor.ensureFile("/cn1libs/CodenameOne.jar");
             Path boot  = extractor.ensureFile("/cn1libs/CLDC11.jar");
+            LOG.debug("Compiler dependencies ready: cn1Jar={}, bootJar={}", cn1, boot);
 
             // Use bundled JDK 8
             Path javac = jdk8.ensureJavac8();
+            LOG.debug("Resolved javac path at {}", javac);
 
             // Write sources
             Path work = Files.createTempDirectory("cn1c-");
+            LOG.debug("Writing source files to {}", work);
             List<Path> sources = new ArrayList<>();
-            for (var f : req.files()) {
+            for (var f : files) {
                 Path p = work.resolve(f.path());
                 Files.createDirectories(p.getParent());
                 Files.writeString(p, f.content(), StandardCharsets.UTF_8);
                 sources.add(p);
+                LOG.trace("Wrote source file {}", p);
             }
 
             List<String> cmd = new ArrayList<>(List.of(
@@ -53,6 +64,8 @@ public class ExternalCompileService {
             }
             sources.forEach(s -> cmd.add(s.toString()));
 
+            LOG.debug("Executing javac command: {}", cmd);
+
             ProcessBuilder pb = new ProcessBuilder(cmd);
             pb.directory(work.toFile());
             pb.redirectErrorStream(true);
@@ -62,9 +75,12 @@ public class ExternalCompileService {
                 out = new String(is.readAllBytes(), StandardCharsets.UTF_8);
             }
             int code = pr.waitFor();
+            LOG.debug("javac exited with code {}", code);
             boolean ok = code == 0 && !out.toLowerCase().contains("error:");
+            LOG.info("Compile finished: ok={}, outputLength={}", ok, out.length());
             return new CompileResponse(ok, out, List.of());
         } catch (Exception e) {
+            LOG.error("Compile failed", e);
             return new CompileResponse(false, e.toString(), List.of());
         }
     }

--- a/src/main/java/com/codename1/server/mcp/service/ScaffoldService.java
+++ b/src/main/java/com/codename1/server/mcp/service/ScaffoldService.java
@@ -3,12 +3,16 @@ package com.codename1.server.mcp.service;
 import com.codename1.server.mcp.dto.FileEntry;
 import com.codename1.server.mcp.dto.ScaffoldRequest;
 import com.codename1.server.mcp.dto.ScaffoldResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import java.util.ArrayList;
 
 @Service
 public class ScaffoldService {
+    private static final Logger LOG = LoggerFactory.getLogger(ScaffoldService.class);
     public ScaffoldResponse scaffold(ScaffoldRequest req) {
+        LOG.info("Generating scaffold for package '{}' and name '{}'", req.pkg(), req.name());
         String pkg = req.pkg();
         String name = req.name();
 
@@ -18,6 +22,7 @@ public class ScaffoldService {
         files.add(new FileEntry("src/main/codenameone/native/android/build.gradle", "// placeholder"));
         files.add(new FileEntry("src/main/codenameone/theme.css", themeCss()));
         files.add(new FileEntry("src/main/codenameone/codenameone_settings.properties", settings()));
+        LOG.debug("Generated scaffold with {} file(s)", files.size());
         return new ScaffoldResponse(files);
     }
 

--- a/src/main/java/com/codename1/server/mcp/service/SnippetService.java
+++ b/src/main/java/com/codename1/server/mcp/service/SnippetService.java
@@ -3,12 +3,15 @@ package com.codename1.server.mcp.service;
 import com.codename1.server.mcp.dto.ExplainResponse;
 import com.codename1.server.mcp.dto.Snippet;
 import com.codename1.server.mcp.dto.SnippetsResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Map;
 
 @Service
 public class SnippetService {
+    private static final Logger LOG = LoggerFactory.getLogger(SnippetService.class);
     private static final Map<String, List<Snippet>> DB = Map.of(
             "rest", List.of(new Snippet("REST GET",
                     "Use Rest with async onComplete; no blocking on EDT.",
@@ -34,10 +37,14 @@ public class SnippetService {
             );
 
     public SnippetsResponse get(String topic) {
-        return new SnippetsResponse(DB.getOrDefault(topic, List.of()));
+        LOG.info("Retrieving snippets for topic '{}'", topic);
+        var snippets = DB.getOrDefault(topic, List.of());
+        LOG.debug("Found {} snippet(s) for topic '{}'", snippets.size(), topic);
+        return new SnippetsResponse(snippets);
     }
 
     public ExplainResponse explain(String ruleId) {
+        LOG.info("Explaining rule '{}'", ruleId);
         return switch (ruleId) {
             case "CN1_EDT_RULE" -> new ExplainResponse(
                     "UI changes must run on the Event Dispatch Thread (EDT).",

--- a/src/main/java/com/codename1/server/mcp/tools/Jdk8ManagerFromResource.java
+++ b/src/main/java/com/codename1/server/mcp/tools/Jdk8ManagerFromResource.java
@@ -1,5 +1,7 @@
 package com.codename1.server.mcp.tools;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -8,6 +10,7 @@ import java.nio.file.*;
 
 @Component
 public class Jdk8ManagerFromResource {
+    private static final Logger LOG = LoggerFactory.getLogger(Jdk8ManagerFromResource.class);
     private final GlobalExtractor extractor;
     private final String jdkArchiveResource;
     private final String rootMarker; // e.g. "release"
@@ -18,34 +21,46 @@ public class Jdk8ManagerFromResource {
         this.extractor = extractor;
         this.jdkArchiveResource = jdkArchiveResource;
         this.rootMarker = rootMarker;
+        LOG.debug("Jdk8Manager configured with resource={} rootMarker={}", jdkArchiveResource, rootMarker);
     }
 
     /** Ensures the bundled JDK 8 archive is extracted, returns path to .../bin/javac */
     public Path ensureJavac8() throws IOException {
+        LOG.debug("Ensuring javac8 is available");
         if (!System.getProperty("os.name").toLowerCase().contains("linux")) {
             // this is a local environment test
+            LOG.warn("Non-Linux OS detected ({}); returning hard-coded javac path", System.getProperty("os.name"));
             return Path.of("/Users/shai/Library/Java/JavaVirtualMachines/azul-1.8.0_372/Contents/Home/bin/javac");
         }
         // The folder name is derived from the archive file name (without extension)
         String fileName = Path.of(jdkArchiveResource).getFileName().toString();          // temurin8-linux-x64.tar.gz
         String folderName = fileName.replace(".tar.gz", "");
         Path jdkRoot = extractor.ensureArchiveExtracted(jdkArchiveResource, folderName);
+        LOG.debug("JDK extracted to {}", jdkRoot);
 
         // Some archives contain a top-level directory (e.g., jdk8uXXX-.../)
         Path root = findJdkRoot(jdkRoot);
         Path javac = root.resolve("bin/javac");
         if (!Files.isExecutable(javac)) throw new IOException("javac not found at " + javac);
+        LOG.info("javac8 located at {}", javac);
         return javac;
     }
 
     private Path findJdkRoot(Path base) throws IOException {
         // If base has 'release' file, it's the root. Otherwise, look one level down.
-        if (Files.exists(base.resolve(rootMarker))) return base;
+        if (Files.exists(base.resolve(rootMarker))) {
+            LOG.trace("Found JDK root marker '{}' directly under {}", rootMarker, base);
+            return base;
+        }
         try (var stream = Files.list(base)) {
             for (Path p : (Iterable<Path>) stream::iterator) {
-                if (Files.isDirectory(p) && Files.exists(p.resolve(rootMarker))) return p;
+                if (Files.isDirectory(p) && Files.exists(p.resolve(rootMarker))) {
+                    LOG.trace("Found JDK root marker '{}' under {}", rootMarker, p);
+                    return p;
+                }
             }
         }
+        LOG.warn("Falling back to {} as JDK root; marker '{}' not found", base, rootMarker);
         return base; // fallback
     }
 }

--- a/src/main/java/com/codename1/server/stdiomcp/StdIoMcpMain.java
+++ b/src/main/java/com/codename1/server/stdiomcp/StdIoMcpMain.java
@@ -6,8 +6,9 @@ import com.codename1.server.mcp.dto.FileEntry;
 import com.codename1.server.mcp.dto.LintRequest;
 import com.codename1.server.mcp.service.ExternalCompileService;
 import com.codename1.server.mcp.service.LintService;
-import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.WebApplicationType;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.context.ConfigurableApplicationContext;
@@ -22,20 +23,22 @@ import java.util.Map;
 
 public class StdIoMcpMain {
 
+    private static final Logger LOG = LoggerFactory.getLogger(StdIoMcpMain.class);
+
     record RpcReq(String jsonrpc, Object id, String method, Map<String,Object> params) {}
     record RpcRes(String jsonrpc, Object id, Object result) {}
     record RpcErr(String jsonrpc, Object id, Map<String,Object> error) {}
 
     public static void main(String[] args) throws Exception {
-        // keep stdout clean; route logs to stderr or disable via profile
-        System.setProperty("org.springframework.boot.logging.LoggingSystem","none");
-
+        LOG.info("Starting Codename One MCP in STDIO mode");
         ConfigurableApplicationContext ctx =
                 new SpringApplicationBuilder(McpApplication.class)
+                        .profiles("stdio")
                         .web(WebApplicationType.NONE)
                         .logStartupInfo(false)
                         .run(args);
 
+        LOG.debug("Application context started with {} beans", ctx.getBeanDefinitionCount());
         var lint = ctx.getBean(LintService.class);
         var compile = ctx.getBean(ExternalCompileService.class);
 
@@ -43,15 +46,25 @@ public class StdIoMcpMain {
         var in  = new BufferedReader(new InputStreamReader(System.in));
         var out = new BufferedWriter(new OutputStreamWriter(System.out));
 
+        LOG.info("STDIO MCP ready. Awaiting JSON-RPC requests");
         while (true) {
             String line = in.readLine();
-            if (line == null) break;
-            if (line.isBlank()) continue;
+            if (line == null) {
+                LOG.info("STDIN closed; shutting down STDIO MCP");
+                break;
+            }
+            if (line.isBlank()) {
+                LOG.trace("Skipping blank input line");
+                continue;
+            }
+
+            LOG.debug("Received raw JSON-RPC payload: {}", line);
 
             RpcReq req;
             try {
                 req = mapper.readValue(line, RpcReq.class);
             } catch (Exception e) {
+                LOG.warn("Failed to parse JSON-RPC request: {}", line, e);
                 // malformed input -> JSON-RPC error with null id
                 writeJson(out, mapper, new RpcErr("2.0", null, Map.of(
                         "code", -32700, "message", "Parse error")));
@@ -59,6 +72,7 @@ public class StdIoMcpMain {
             }
 
             try {
+                LOG.info("Handling method '{}' with id {}", req.method, req.id);
                 switch (req.method) {
                     case "initialize" -> {
                         var result = Map.of(
@@ -70,6 +84,7 @@ public class StdIoMcpMain {
                                         "resources", Map.of()
                                 )
                         );
+                        LOG.debug("initialize response: {}", result);
                         writeJson(out, mapper, new RpcRes("2.0", req.id, result));
                     }
 
@@ -103,6 +118,7 @@ public class StdIoMcpMain {
                                         )
                                 )
                         );
+                        LOG.debug("tools/list returning {} tools", tools.size());
                         writeJson(out, mapper, new RpcRes("2.0", req.id, Map.of("tools", tools)));
                     }
 
@@ -112,55 +128,63 @@ public class StdIoMcpMain {
                         Map<String,Object> params = (Map<String,Object>) req.params.getOrDefault("arguments", Map.of());
 
                         Object toolPayload;
+                        LOG.info("Invoking tool '{}'", name);
                         switch (name) {
                             case "cn1_lint_code" -> {
                                 String code = (String) params.get("code");
+                                LOG.debug("Lint request received ({} chars)", code != null ? code.length() : 0);
                                 toolPayload = lint.lint(new LintRequest(code, "java", List.of()));
                             }
                             case "cn1_compile_check" -> {
                                 @SuppressWarnings("unchecked")
                                 var files = ((List<Map<String,Object>>) params.get("files")).stream()
                                         .map(m -> new FileEntry((String)m.get("path"), (String)m.get("content"))).toList();
+                                LOG.debug("Compile request received with {} file(s)", files.size());
                                 toolPayload = compile.compile(new CompileRequest(files, null));
                             }
                             default -> throw new IllegalArgumentException("Unknown tool: " + name);
                         }
 
-                        // Wrap as content array (text block). If you prefer structured, you can also return the object directly—
-                        // but this format is universally accepted by Claude frontends.
                         var result = Map.of("content", List.of(
                                 Map.of("type", "text", "text", mapper.writeValueAsString(toolPayload))
                         ));
+                        LOG.debug("tools/call '{}' result: {}", name, result);
                         writeJson(out, mapper, new RpcRes("2.0", req.id, result));
                     }
 
                     case "notifications/initialized", "ping" -> {
-                        // no response required for notifications; for ping, you can echo a result if the client sends a request id
+                        LOG.debug("Received notification '{}'", req.method);
                         if (req.id != null) writeJson(out, mapper, new RpcRes("2.0", req.id, Map.of("ok", true)));
                     }
 
                     case "prompts/list" -> {
+                        LOG.debug("prompts/list requested");
                         writeJson(out, mapper, new RpcRes("2.0", req.id, Map.of("prompts", List.of())));
                     }
                     case "resources/list" -> {
+                        LOG.debug("resources/list requested");
                         writeJson(out, mapper, new RpcRes("2.0", req.id, Map.of("resources", List.of())));
                     }
 
                     default -> {
+                        LOG.warn("Unknown method '{}'", req.method);
                         writeJson(out, mapper, new RpcErr("2.0", req.id, Map.of(
                                 "code", -32601, "message", "Method not found: " + req.method)));
                     }
                 }
             } catch (Exception ex) {
+                LOG.error("Error handling request {} {}", req.id, req.method, ex);
                 writeJson(out, mapper, new RpcErr("2.0", req.id, Map.of(
                         "code", -32000, "message", ex.toString())));
             }
         }
+        LOG.info("STDIO MCP terminated");
     }
 
     private static void writeJson(BufferedWriter out, ObjectMapper mapper, Object obj) throws IOException {
         out.write(mapper.writeValueAsString(obj));
         out.write("\n");
         out.flush();
+        LOG.trace("Sent JSON-RPC payload: {}", obj);
     }
 }

--- a/src/main/java/com/codename1/server/stdiomcp/StdIoMcpMain.java
+++ b/src/main/java/com/codename1/server/stdiomcp/StdIoMcpMain.java
@@ -30,7 +30,6 @@ public class StdIoMcpMain {
     record RpcErr(String jsonrpc, Object id, Map<String,Object> error) {}
 
     public static void main(String[] args) throws Exception {
-        LOG.info("Starting Codename One MCP in STDIO mode");
         ConfigurableApplicationContext ctx =
                 new SpringApplicationBuilder(McpApplication.class)
                         .profiles("stdio")

--- a/src/main/resources/application-stdio.properties
+++ b/src/main/resources/application-stdio.properties
@@ -1,6 +1,7 @@
 spring.main.banner-mode=off
 spring.main.log-startup-info=false
 spring.output.ansi.enabled=NEVER
-logging.level.root=OFF
-logging.level.org.springframework=OFF
-logging.level.org.apache=OFF
+logging.level.root=INFO
+logging.level.org.springframework=WARN
+logging.level.org.apache=WARN
+logging.level.com.codename1.server=DEBUG

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 spring.application.name=mcp
-cn1.cacheDir= ${user.home}/.cn1-mcp
+cn1.cacheDir=${user.home}/.cn1-mcp
 cn1.libsVersionTag=v1
 cn1.jdk8.resourcePath=/cn1libs/OpenJDK8U-jdk_x64_linux_hotspot_8u462b08.tar.gz
 cn1.jdk8.rootMarker=release

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+    <springProperty scope="context" name="cacheDir" source="cn1.cacheDir" defaultValue="${USER_HOME}/.cn1-mcp"/>
+    <property name="LOG_DIR" value="${cacheDir}/logs"/>
+    <property name="STDIO_LOG_FILE" value="${LOG_DIR}/mcp-stdio.log"/>
+
+    <springProfile name="stdio">
+        <appender name="STDIO_FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
+            <file>${STDIO_LOG_FILE}</file>
+            <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+                <fileNamePattern>${LOG_DIR}/mcp-stdio.%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+                <maxFileSize>10MB</maxFileSize>
+                <maxHistory>7</maxHistory>
+                <totalSizeCap>200MB</totalSizeCap>
+            </rollingPolicy>
+            <encoder>
+                <pattern>${FILE_LOG_PATTERN}</pattern>
+            </encoder>
+        </appender>
+
+        <logger name="com.codename1.server" level="DEBUG" additivity="false">
+            <appender-ref ref="STDIO_FILE"/>
+        </logger>
+
+        <root level="INFO">
+            <appender-ref ref="STDIO_FILE"/>
+        </root>
+    </springProfile>
+
+    <springProfile name="!stdio">
+        <include resource="org/springframework/boot/logging/logback/console-appender.xml"/>
+        <logger name="com.codename1.server" level="DEBUG"/>
+        <root level="INFO">
+            <appender-ref ref="CONSOLE"/>
+        </root>
+    </springProfile>
+</configuration>

--- a/src/test/java/com/codename1/server/stdiomcp/StdIoMcpMainTest.java
+++ b/src/test/java/com/codename1/server/stdiomcp/StdIoMcpMainTest.java
@@ -1,0 +1,143 @@
+package com.codename1.server.stdiomcp;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.concurrent.*;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class StdIoMcpMainTest {
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private InputStream originalIn;
+    private PrintStream originalOut;
+    private PipedOutputStream inputFeeder;
+    private BufferedWriter stdinWriter;
+    private BufferedReader stdoutReader;
+    private Thread mainThread;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        originalIn = System.in;
+        originalOut = System.out;
+
+        var stdIn = new PipedInputStream();
+        inputFeeder = new PipedOutputStream(stdIn);
+        System.setIn(stdIn);
+        stdinWriter = new BufferedWriter(new OutputStreamWriter(inputFeeder, StandardCharsets.UTF_8));
+
+        var stdoutPipe = new PipedInputStream();
+        var stdoutSink = new PipedOutputStream(stdoutPipe);
+        System.setOut(new PrintStream(stdoutSink, true, StandardCharsets.UTF_8));
+        stdoutReader = new BufferedReader(new InputStreamReader(stdoutPipe, StandardCharsets.UTF_8));
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        try {
+            if (stdinWriter != null) {
+                stdinWriter.close();
+            }
+            if (inputFeeder != null) {
+                inputFeeder.close();
+            }
+        } finally {
+            if (mainThread != null) {
+                mainThread.join(5000);
+            }
+            System.setIn(originalIn);
+            System.setOut(originalOut);
+        }
+    }
+
+    @Test
+    void stdioMainHandlesInitializeAndLintCall() throws Exception {
+        mainThread = new Thread(() -> {
+            try {
+                StdIoMcpMain.main(new String[]{"--spring.profiles.active=stdio"});
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }, "stdio-main-test");
+        mainThread.start();
+
+        // wait briefly for Spring context to spin up
+        Thread.sleep(500);
+
+        sendRequest(Map.of(
+                "jsonrpc", "2.0",
+                "id", 1,
+                "method", "initialize",
+                "params", Map.of("protocolVersion", "2025-06-18")
+        ));
+        Map<String, Object> initResponse = readJsonResponse();
+        assertEquals("2.0", initResponse.get("jsonrpc"));
+        assertEquals(1, initResponse.get("id"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> initResult = (Map<String, Object>) initResponse.get("result");
+        assertNotNull(initResult);
+        assertEquals("2025-06-18", initResult.get("protocolVersion"));
+
+        sendRequest(Map.of(
+                "jsonrpc", "2.0",
+                "id", 2,
+                "method", "tools/list",
+                "params", Map.of()
+        ));
+        Map<String, Object> toolsResponse = readJsonResponse();
+        assertEquals(2, toolsResponse.get("id"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> toolsResult = (Map<String, Object>) toolsResponse.get("result");
+        assertNotNull(toolsResult);
+        assertTrue(toolsResult.containsKey("tools"));
+
+        sendRequest(Map.of(
+                "jsonrpc", "2.0",
+                "id", 3,
+                "method", "tools/call",
+                "params", Map.of(
+                        "name", "cn1_lint_code",
+                        "arguments", Map.of("code", "public class Foo {}"))
+        ));
+        Map<String, Object> lintResponse = readJsonResponse();
+        assertEquals(3, lintResponse.get("id"));
+        @SuppressWarnings("unchecked")
+        Map<String, Object> lintResult = (Map<String, Object>) lintResponse.get("result");
+        assertNotNull(lintResult);
+        assertTrue(lintResult.containsKey("content"));
+        assertThat(lintResult.get("content").toString()).contains("\"ok\":true");
+
+        // Close STDIN to terminate the loop cleanly
+        stdinWriter.close();
+        inputFeeder.close();
+        mainThread.join(5000);
+        assertFalse(mainThread.isAlive(), "STDIO loop should exit after EOF");
+    }
+
+    private void sendRequest(Map<String, Object> payload) throws IOException {
+        stdinWriter.write(mapper.writeValueAsString(payload));
+        stdinWriter.write("\n");
+        stdinWriter.flush();
+    }
+
+    private Map<String, Object> readJsonResponse() throws Exception {
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            Future<String> future = executor.submit(stdoutReader::readLine);
+            String line = future.get(5, TimeUnit.SECONDS);
+            assertNotNull(line, "Expected JSON-RPC response but got EOF");
+            assertTrue(line.startsWith("{"), "Response must be JSON but was: " + line);
+            return mapper.readValue(line, new TypeReference<>() {});
+        } finally {
+            executor.shutdownNow();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- force the stdio profile when launching StdIoMcpMain so its logging is always routed through the file appender
- add an end-to-end StdIoMcpMain test that exercises initialize, tools/list, and lint tool calls over JSON-RPC stdio
- add a GitHub Action that provisions Java 25 and runs the Maven build with the stdio profile enabled

## Testing
- `./mvnw -B test` *(fails: container JDK 21 cannot target release 25)*

------
https://chatgpt.com/codex/tasks/task_e_68e4eb079ab8833187c0d08a80199d0c