### PR TITLE
Update guide mode resource URIs to standard scheme

### DIFF
--- a/src/main/java/com/codename1/server/mcp/service/GuideService.java
+++ b/src/main/java/com/codename1/server/mcp/service/GuideService.java
@@ -1,0 +1,102 @@
+package com.codename1.server.mcp.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.ResourcePatternResolver;
+import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Discovers the markdown guides bundled with the MCP server and exposes simple metadata and
+ * content loading helpers so they can be surfaced via guide/intro mode.
+ */
+@Service
+public class GuideService {
+    private static final Logger LOG = LoggerFactory.getLogger(GuideService.class);
+    private final List<GuideDoc> guides;
+    private final Map<String, GuideDoc> guidesById;
+
+    public GuideService(ResourcePatternResolver resolver) {
+        List<GuideDoc> discovered = new ArrayList<>();
+        try {
+            for (Resource resource : resolver.getResources("classpath:/static/docs/*.md")) {
+                if (resource == null || !resource.exists()) {
+                    continue;
+                }
+                String filename = resource.getFilename();
+                if (filename == null) {
+                    continue;
+                }
+                String id = toId(filename);
+                String title = toTitle(filename);
+                String description = title + " (Codename One guide)";
+                GuideDoc guide = new GuideDoc(id, title, description, resource);
+                LOG.debug("Registered guide {} from resource {}", id, resource);
+                discovered.add(guide);
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to discover bundled guides", e);
+        }
+
+        discovered.sort((a, b) -> a.id().compareToIgnoreCase(b.id()));
+        this.guides = Collections.unmodifiableList(discovered);
+        Map<String, GuideDoc> map = new LinkedHashMap<>();
+        for (GuideDoc guide : discovered) {
+            map.put(guide.id(), guide);
+        }
+        this.guidesById = Collections.unmodifiableMap(map);
+        LOG.info("Discovered {} bundled guide(s)", this.guides.size());
+    }
+
+    public List<GuideDoc> listGuides() {
+        return guides;
+    }
+
+    public Optional<GuideDoc> findGuide(String id) {
+        return Optional.ofNullable(guidesById.get(id));
+    }
+
+    public String loadGuide(String id) throws IOException {
+        GuideDoc guide = guidesById.get(id);
+        if (guide == null) {
+            throw new IllegalArgumentException("Unknown guide: " + id);
+        }
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(
+                guide.resource().getInputStream(), StandardCharsets.UTF_8))) {
+            return reader.lines().collect(Collectors.joining("\n"));
+        }
+    }
+
+    private static String toId(String filename) {
+        String base = stripExtension(filename);
+        String slug = base.replaceAll("[^A-Za-z0-9]+", "-");
+        slug = slug.replaceAll("^-+", "").replaceAll("-+$", "");
+        return slug.toLowerCase(Locale.ROOT);
+    }
+
+    private static String toTitle(String filename) {
+        String base = stripExtension(filename);
+        return base.replace('_', ' ').replace('-', ' ');
+    }
+
+    private static String stripExtension(String filename) {
+        int dot = filename.lastIndexOf('.');
+        return dot >= 0 ? filename.substring(0, dot) : filename;
+    }
+
+    public record GuideDoc(String id, String title, String description, Resource resource) {}
+}
+

--- a/src/main/java/com/codename1/server/stdiomcp/StdIoMcpMain.java
+++ b/src/main/java/com/codename1/server/stdiomcp/StdIoMcpMain.java
@@ -214,7 +214,7 @@ public class StdIoMcpMain {
                                     writeJson(out, mapper, new RpcRes("2.0", req.id, Map.of("contents", List.of(content))));
                                 } catch (IOException e) {
                                     LOG.error("Failed to load guide {} for request id={}: {}", guideId, req.id, e.getMessage(), e);
-                                    writeJson(out, mapper, new RpcRes("2.0", req.id, null, Map.of(
+                                    writeJson(out, mapper, new RpcRes("2.0", req.id, Map.of(
                                         "code", -32001,
                                         "message", "Failed to load guide: " + e.getMessage()
                                     )));

--- a/src/test/java/com/codename1/server/stdiomcp/StdIoMcpMainTest.java
+++ b/src/test/java/com/codename1/server/stdiomcp/StdIoMcpMainTest.java
@@ -53,4 +53,55 @@ class StdIoMcpMainTest {
         Map<?,?> lintPayload = mapper.readValue(payload, Map.class);
         assertEquals(Boolean.TRUE, lintPayload.get("ok"));
     }
+
+    @Test
+    void guideModeListsMarkdownResources() throws Exception {
+        Path cacheDir = Files.createTempDirectory("cn1-mcp-test-cache");
+        String requests = String.join("\n", List.of(
+                "{\"jsonrpc\":\"2.0\",\"id\":10,\"method\":\"initialize\",\"params\":{}}",
+                "{\"jsonrpc\":\"2.0\",\"id\":11,\"method\":\"modes/list\",\"params\":{}}",
+                "{\"jsonrpc\":\"2.0\",\"id\":12,\"method\":\"modes/set\",\"params\":{\"mode\":\"cn1_guide\"}}",
+                "{\"jsonrpc\":\"2.0\",\"id\":13,\"method\":\"resources/list\",\"params\":{}}",
+                "{\"jsonrpc\":\"2.0\",\"id\":14,\"method\":\"resources/read\",\"params\":{\"uri\":\"guide://cn1-idioms\"}}"
+        )) + "\n";
+
+        var in = new ByteArrayInputStream(requests.getBytes(StandardCharsets.UTF_8));
+        var out = new ByteArrayOutputStream();
+
+        StdIoMcpMain.runWithStreams(in, out, new String[]{"--cn1.cacheDir=" + cacheDir.toAbsolutePath()});
+
+        String[] lines = out.toString(StandardCharsets.UTF_8).trim().split("\\R");
+        assertEquals(5, lines.length, "Expected five JSON-RPC responses");
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        Map<?,?> modes = mapper.readValue(lines[1], Map.class);
+        Map<?,?> modesResult = (Map<?,?>) modes.get("result");
+        List<?> modeList = (List<?>) modesResult.get("modes");
+        assertTrue(modeList.stream().anyMatch(m -> "cn1_guide".equals(((Map<?,?>) m).get("name"))));
+
+        Map<?,?> setRes = mapper.readValue(lines[2], Map.class);
+        Map<?,?> setResult = (Map<?,?>) setRes.get("result");
+        assertEquals("cn1_guide", setResult.get("mode"));
+
+        Map<?,?> resourcesList = mapper.readValue(lines[3], Map.class);
+        Map<?,?> resourcesResult = (Map<?,?>) resourcesList.get("result");
+        List<?> resources = (List<?>) resourcesResult.get("resources");
+        assertFalse(resources.isEmpty(), "Guide mode should expose markdown resources");
+        @SuppressWarnings("unchecked")
+        Map<String,Object> firstResource = (Map<String,Object>) resources.get(0);
+        assertEquals("guide://cn1-idioms", firstResource.get("uri"));
+        assertEquals("CN1 Idioms", firstResource.get("name"));
+        assertEquals("CN1 Idioms (Codename One guide)", firstResource.get("description"));
+        assertEquals("text/markdown", firstResource.get("mimeType"));
+
+        Map<?,?> read = mapper.readValue(lines[4], Map.class);
+        Map<?,?> readResult = (Map<?,?>) read.get("result");
+        List<?> contents = (List<?>) readResult.get("contents");
+        Map<?,?> content = (Map<?,?>) contents.get(0);
+        String text = (String) content.get("text");
+        assertEquals("guide://cn1-idioms", content.get("uri"));
+        assertEquals("text/markdown", content.get("mimeType"));
+        assertTrue(text.contains("Codename One Idioms"));
+    }
 }


### PR DESCRIPTION
## Summary
- update the stdio MCP resource descriptors to emit `guide://` URIs and validate the same scheme during reads
- extend the stdio integration test to cover the standard resource metadata shape and markdown response

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68e62f3e23f4833181bfac6a31c361af