### PR TITLE
Split Codename One CSS guide into modular docs

### DIFF
--- a/src/main/resources/static/docs/CN1_Restrictions.md
+++ b/src/main/resources/static/docs/CN1_Restrictions.md
@@ -40,5 +40,19 @@
 ## Theming
 - Prefer UIIDs + CN1 CSS/Theme. Minimize per-component, hard-coded styles.
 
+## CSS Support (Codename One Theme Compiler)
+- See the `css/` subdirectory in this folder for topic-specific guides and ready-to-copy snippets. Start with `css/Overview.md`.
+- Selectors map to UIIDs, with `.pressed`, `.selected`, `.unselected`, and `.disabled` as the built-in pseudo classes for component state. Use comma lists for multiple UIIDs and `cn1-derive` for inheritance.
+- `#Device`, `#Constants`, and `Default` selectors respectively constrain generated resolutions, declare theme constants (including multi-images), and populate the implicit base UIID.
+- Standard properties include padding/margin, border (and variants), border-radius, background/background-image/background-repeat, border-image/border-image-slice, font*, color, text-align, text-decoration (including `cn1-3d` variants), opacity, box-shadow, and width/height (for asset generation).
+- Codename One extensions cover `cn1-source-dpi`, `cn1-background-type`, `cn1-derive`, `cn1-9patch` (deprecated), and the `cn1-box-shadow-*` family for round/pill borders.
+- CSS variables via `var(--name, fallback)` are supported inside property values; define them in `#Constants` or selectors.
+- Complex borders/backgrounds fall back to 9-piece images when they can’t be rendered natively; use `cn1-round-border`, `cn1-pill-border`, or simplified gradients/shadows to avoid bloating the resource file.
+- Background precedence: image borders override background images, which override colors. Use `border: none` to reveal lower-priority backgrounds.
+- Images can be batched via comma-separated `background-image` declarations. Remote URLs are allowed for single assets (including fonts) but multi-image inputs must be local and organized by density (`verylow.png`, `low.png`, … `4k.png`).
+- Fonts default to `native:*` families. Bundle TTF/OTF fonts with `@font-face` (local, HTTP(S), or `github://` sources) and normalize base sizes with constants like `defaultFontSizeInt` and `defaultDesktopFontSizeInt`.
+- Media queries accept only `platform-*`, `device-*`, and `density-*`. Terms separated by commas combine (`OR` within type, `AND` across types). Precedence favors media-query styles, then more-specific query groups, with tie-breaker order platform > device > density. Matching font-scale constants (e.g., `device-desktop-font-scale`) multiply together.
+
 ## Lifecycle
 - Respect `init/start/stop/destroy` flow. Show forms from `start()` or on the EDT.
+

--- a/src/main/resources/static/docs/css/Assets.md
+++ b/src/main/resources/static/docs/css/Assets.md
@@ -1,0 +1,82 @@
+# Images and Asset Handling
+
+Codename One CSS can both consume and generate multi-image assets. Use these patterns to control density, locations, and constants.
+
+## Declaring Source DPI
+
+```css
+HeroBanner {
+    background-image: url(images/banner.png);
+    cn1-source-dpi: 320;
+}
+```
+
+* Values ≤120 are treated as low density, 121–160 as medium, 161–320 as very high, 321–480 as HD, and >480 as 2HD.
+* Set `cn1-source-dpi: 0;` to import an image without generating multi-image variants.
+
+## Providing Multi-Image Inputs
+
+Organize pre-rendered densities inside a directory named after the image:
+
+```
+css/
+ ├── theme.css
+ └── images/
+      └── logo.png/
+           ├── verylow.png
+           ├── low.png
+           ├── medium.png
+           ├── high.png
+           ├── veryhigh.png
+           ├── hd.png
+           └── 2hd.png
+```
+
+Then reference the logical name:
+
+```css
+BrandHeader {
+    background-image: url(images/logo.png);
+}
+```
+
+## Loading Remote Assets
+
+Remote URLs download once during compilation and are cached locally afterward.
+
+```css
+Splash {
+    background-image: url(https://example.com/art/splash.png);
+}
+```
+
+## Image Constants
+
+Strings ending with `Image` inside `#Constants` resolve to multi-images if the asset exists:
+
+```css
+#Constants {
+    menuImage: "menu.png";
+}
+```
+
+This example searches `res/theme.css/menu.png/` for the density variants. If they are missing, ensure the image appears in a `background-image` elsewhere in the CSS.
+
+## Importing Bundles of Images
+
+Declare an unused selector to pull multiple assets into the compiled resource file:
+
+```css
+Images {
+    background-image: url(images/NowLogo.png),
+        url(images/Username-icon.png),
+        url(images/Password-icon.png);
+}
+```
+
+At runtime, use `Resources` to retrieve them:
+
+```java
+Resources theme = Resources.openLayered("/theme");
+Label bookmark = new Label(theme.getImage("Password-icon.png"));
+```

--- a/src/main/resources/static/docs/css/BackgroundsAndBorders.md
+++ b/src/main/resources/static/docs/css/BackgroundsAndBorders.md
@@ -1,0 +1,98 @@
+# Backgrounds and Borders
+
+Codename One renders many borders natively, but complex shapes fall back to generated 9-piece images at build time.
+
+## Round Borders
+
+### Built-in Styles
+
+```css
+RoundButton {
+    border: 1px #3399ff cn1-round-border;
+    padding: 3mm;
+}
+
+PillButton {
+    border: 1pt #3399ff cn1-pill-border;
+    color: white;
+    background: cn1-pill-border;
+    background-color: #3399ff;
+}
+```
+
+`cn1-round-border` and `cn1-pill-border` avoid generating image borders and are efficient for circular or pill shapes.
+
+### `border-radius`
+
+```css
+Badge {
+    background-color: red;
+    border-radius: 2mm;
+    padding: 1mm 2mm;
+}
+```
+
+If the declaration can be represented with `RoundRectBorder`, the compiler keeps it native; otherwise it generates a 9-piece image.
+
+## Shadows on Round Borders
+
+Use the Codename One shadow extensions instead of standard `box-shadow` to avoid image generation.
+
+```css
+PillButton {
+    border: 1pt #3399ff cn1-pill-border;
+    cn1-box-shadow-color: rgba(0, 0, 0, 0.35);
+    cn1-box-shadow-spread: 1mm;
+    cn1-box-shadow-h: 0;
+    cn1-box-shadow-v: 1mm;
+    cn1-box-shadow-blur: 2mm;
+}
+```
+
+## Image Borders
+
+```css
+Card {
+    border-image: url('dashbg_landscape.png');
+    border-image-slice: 10% 30% 40% 20%;
+}
+```
+
+Omit `border-image-slice` to use the default 40% inset.
+
+## Background Layers
+
+Priority order:
+
+1. Image border (covers the entire component)
+2. Background image (`background-image` / `background`)
+3. Background color (`background-color`)
+
+Disable higher layers if you want lower ones to show through:
+
+```css
+Card {
+    border: none;
+    background-color: #f5f5f5;
+}
+```
+
+## Gradient Support
+
+Native linear gradients must have exactly two color stops with matching alpha, and a direction of `0deg`, `90deg`, `180deg`, or `270deg` (or matching keywords).
+
+```css
+Banner {
+    background: linear-gradient(to top, #ccc, #666);
+}
+```
+
+Other gradients generate background images during compilation.
+
+Radial gradients render natively when the first stop starts at `0%`.
+
+```css
+Badge {
+    background: radial-gradient(circle at left, gray, white);
+}
+```

--- a/src/main/resources/static/docs/css/Fonts.md
+++ b/src/main/resources/static/docs/css/Fonts.md
@@ -1,0 +1,58 @@
+# Fonts
+
+Codename One CSS supports native fonts, @font-face imports, and Codename One theme constants for default sizing.
+
+## Native Fonts
+
+```css
+SideCommand {
+    font-family: "native:MainThin";
+    font-size: 1.8mm;
+}
+```
+
+Available families include `native:MainThin`, `native:MainLight`, `native:MainRegular`, `native:MainBold`, `native:MainBlack`, and their italic counterparts.
+
+## TrueType / OpenType Fonts
+
+Define fonts with `@font-face` and reference them by the declared family name:
+
+```css
+@font-face {
+    font-family: "Montserrat";
+    src: url(res/Montserrat-Regular.ttf);
+}
+
+Heading {
+    font-family: "Montserrat";
+    font-size: 4mm;
+}
+```
+
+Remote URLs are downloaded once during compilation and cached locally.
+
+## Font Sizes
+
+Prefer physical units such as millimetres (`mm`) for consistent results across densities.
+
+```css
+Label {
+    font-size: 2.2mm;
+}
+```
+
+Percentages are measured relative to the platform’s medium font size (`150%` == `1.5rem`).
+
+## Theme-Level Defaults
+
+Set baseline font sizes with constants so your design scales predictably.
+
+```css
+#Constants {
+    defaultFontSizeInt: 18;
+    defaultDesktopFontSizeInt: 14;
+    device-phone-font-scale: "1.2";
+}
+```
+
+`device-*`, `platform-*`, and `density-*` font-scale constants multiply together when multiple entries apply at runtime.

--- a/src/main/resources/static/docs/css/JavaIntegration.md
+++ b/src/main/resources/static/docs/css/JavaIntegration.md
@@ -1,0 +1,50 @@
+# Java Integration
+
+These snippets illustrate how to apply Codename One CSS UIIDs and assets from your code.
+
+## Applying Custom UIIDs
+
+```java
+Button primary = new Button("Submit");
+primary.setUIID("MyPrimaryButton");
+```
+
+Match `MyPrimaryButton` to a selector defined in your CSS file.
+
+## Loading Resources
+
+```java
+Resources theme = Resources.openLayered("/theme");
+Image logo = theme.getImage("NowLogo.png");
+Label header = new Label(logo);
+```
+
+`openLayered` loads the CSS-compiled `.res` file generated under the `src` directory.
+
+## Multi-Image Assets
+
+Retrieve density-aware images by the logical name declared in CSS or `#Constants`:
+
+```java
+Image menuIcon = theme.getImage("menu.png");
+Button menu = new Button(menuIcon);
+```
+
+## Applying Theme Constants
+
+```java
+boolean centeredPopup = theme.getBoolean("centeredPopupBool", false);
+UIManager.getInstance().getLookAndFeel().setDefaultDecorationTransitionName(
+        theme.getString("dialogTransitionIn", "fade"));
+```
+
+## Styling Containers Dynamically
+
+```java
+Container card = new Container(BoxLayout.y());
+card.setUIID(Display.getInstance().isTablet() ? "TabletCard" : "Card");
+card.getAllStyles().setMarginUnit(Style.UNIT_TYPE_MM);
+card.getAllStyles().setMargin(1, 1, 1, 1);
+```
+
+Switching UIIDs at runtime lets you reuse the same CSS while adjusting layout for different devices.

--- a/src/main/resources/static/docs/css/MediaQueries.md
+++ b/src/main/resources/static/docs/css/MediaQueries.md
@@ -1,0 +1,69 @@
+# Media Queries
+
+Codename One’s CSS compiler evaluates media queries during build time to emit platform- and density-specific styles.
+
+## Supported Tokens
+
+* `platform-xxx` – e.g. `platform-and`, `platform-ios`, `platform-mac`, `platform-win`
+* `density-xxx` – e.g. `density-low`, `density-high`, `density-2hd`
+* `device-xxx` – `device-phone`, `device-tablet`, `device-desktop`
+
+## Example: Platform Overrides
+
+```css
+Label {
+    color: black;
+}
+
+@media platform-and {
+    Label { color: green; }
+}
+
+@media platform-ios {
+    Label { color: red; }
+}
+```
+
+Styles inside `@media` blocks override declarations outside them.
+
+## Example: Density Buckets
+
+```css
+@media density-very-low, density-low, density-medium {
+    Label { font-size: 2.2mm; }
+}
+
+@media density-high, density-very-high, density-hd, density-2hd {
+    Label { font-size: 2.6mm; }
+}
+```
+
+Same-type queries separated by commas are OR’d together; different types are AND’d.
+
+## Example: Compound Queries
+
+```css
+@media platform-and, density-high {
+    Button { font-size: 2.4mm; }
+}
+
+@media platform-ios, density-high, density-low {
+    Button { font-size: 2.5mm; }
+}
+```
+
+When multiple media blocks target the same selector, precedence is determined by the number of matched tokens, then by token type order (platform > device > density).
+
+## Font Scaling Constants
+
+Instead of redefining every selector, apply font scaling through constants:
+
+```css
+#Constants {
+    device-phone-font-scale: "1.5";
+    platform-ios-font-scale: "0.9";
+    density-low-font-scale: "1.2";
+}
+```
+
+All matching scale values multiply together at runtime.

--- a/src/main/resources/static/docs/css/Overview.md
+++ b/src/main/resources/static/docs/css/Overview.md
@@ -1,0 +1,61 @@
+# Codename One CSS Overview
+
+Codename One CSS themes map selectors onto UIIDs rather than DOM elements. Use these topic-specific guides for details and ready-to-run snippets:
+
+* [Selectors](Selectors.md)
+* [Special Selectors and Constants](SpecialSelectors.md)
+* [Core Properties](Properties.md)
+* [Backgrounds and Borders](BackgroundsAndBorders.md)
+* [Images and Assets](Assets.md)
+* [Fonts](Fonts.md)
+* [Media Queries](MediaQueries.md)
+* [Java Integration](JavaIntegration.md)
+
+## Quick Start Template
+
+Copy the following scaffold into a new `theme.css` and adjust UIIDs as needed:
+
+```css
+#Device {
+    min-resolution: 120dpi;
+    max-resolution: 480dpi;
+}
+
+#Constants {
+    defaultFontSizeInt: 18;
+    defaultDesktopFontSizeInt: 14;
+    menuImage: "menu.png";
+}
+
+Default {
+    font-family: "native:MainRegular";
+    color: black;
+}
+
+Button {
+    padding: 2mm 3mm;
+    border: 1pt solid #3399ff;
+    cn1-background-type: cn1-image-scaled-fill;
+    background: linear-gradient(0deg, #6fa8ff, #2a5cc6);
+}
+
+Button.pressed {
+    background-color: #204c9b;
+}
+
+MyButton {
+    cn1-derive: Button;
+    background-color: #004b8d;
+    text-align: center;
+}
+
+@media platform-ios, density-high {
+    Button {
+        font-size: 2.5mm;
+    }
+}
+```
+
+## Snippet Directory
+
+Practical snippets live in [`css/snippets`](snippets/). Copy the CSS or Java samples directly into MCP prompts when you need starting points.

--- a/src/main/resources/static/docs/css/Properties.md
+++ b/src/main/resources/static/docs/css/Properties.md
@@ -1,0 +1,61 @@
+# Core Properties
+
+Codename One supports a useful subset of standard CSS properties. This sheet highlights the most common ones with sample usage.
+
+## Spacing
+
+```css
+Card {
+    padding: 2mm;
+    margin: 1mm 2mm 3mm;
+}
+```
+
+Use shorthand (`padding`, `margin`) or side-specific forms (`padding-left`, `margin-top`).
+
+## Borders
+
+```css
+ToolbarButton {
+    border: 1pt solid #3399ff;
+    border-radius: 1mm;
+}
+```
+
+* Mixing widths or colors on individual sides may trigger image border generation.
+* Set `border: none;` to disable an inherited image border.
+
+## Backgrounds
+
+```css
+HeroBanner {
+    background: linear-gradient(0deg, #ccc, #666);
+    cn1-background-type: cn1-image-scaled-fill;
+}
+```
+
+* Gradients with two stops and cardinal directions compile to native gradients; others become generated images.
+* Image borders override `background` declarations unless disabled.
+
+## Typography
+
+```css
+Label {
+    font-family: "native:MainRegular";
+    font-size: 2.2mm;
+    font-style: italic;
+    font-weight: bold;
+    color: #222;
+    text-decoration: underline;
+}
+```
+
+Codename One extends `text-decoration` with `cn1-3d`, `cn1-3d-lowered`, and `cn1-3d-shadow-north` for embossed text effects.
+
+## Effects and Utility
+
+* `opacity: 0.5;`
+* `box-shadow: 0 1mm 2mm rgba(0, 0, 0, 0.25);`
+* `width`/`height`: respected when generating background or border images.
+
+Refer to the other topic guides for Codename One–specific extensions such as `cn1-source-dpi` and `cn1-background-type`.

--- a/src/main/resources/static/docs/css/Selectors.md
+++ b/src/main/resources/static/docs/css/Selectors.md
@@ -1,0 +1,73 @@
+# Selectors
+
+Codename One interprets CSS selectors as UIIDs rather than DOM nodes. Focus on mapping selectors to component names defined in your theme.
+
+## UIID Selectors
+
+```css
+Button {
+    padding: 2mm 3mm;
+    text-align: center;
+}
+```
+
+* `Button` targets the UIID named `Button` in the Codename One theme.
+* Use multiple selectors to share rules:
+  ```css
+  Button, TextField, Form {
+      font-size: 2mm;
+  }
+  ```
+
+## State Selectors
+
+Codename One supports four state pseudo-classes:
+
+* `.pressed`
+* `.selected`
+* `.unselected`
+* `.disabled`
+
+```css
+Button.pressed {
+    background-color: #999;
+}
+```
+
+If no state is specified, the selector applies to all states.
+
+## Deriving Styles
+
+Use `cn1-derive` to inherit declarations from another UIID and override only what you need:
+
+```css
+MyPrimaryButton {
+    cn1-derive: Button;
+    border-radius: 2mm;
+    background-color: #004b8d;
+}
+```
+
+Add the new UIID to components in Java:
+
+```java
+Button cta = new Button("Continue");
+cta.setUIID("MyPrimaryButton");
+```
+
+## Grouping for Theme Variants
+
+Combine selectors to define light and dark variants without duplicating files. For example:
+
+```css
+/* Base */
+Label { color: #222; }
+
+/* Dark variant */
+Dark.Label {
+    cn1-derive: Label;
+    color: #fafafa;
+}
+```
+
+Apply the variant UIID to forms or specific components when generating themes.

--- a/src/main/resources/static/docs/css/SpecialSelectors.md
+++ b/src/main/resources/static/docs/css/SpecialSelectors.md
@@ -1,0 +1,45 @@
+# Special Selectors and Theme Constants
+
+Codename One includes three special selectors that influence build-time behavior.
+
+## `#Device`
+
+Restrict the densities generated when compiling CSS into a resource file.
+
+```css
+#Device {
+    min-resolution: 160dpi;
+    max-resolution: 480dpi;
+    resolution: 320dpi; /* optional default */
+}
+```
+
+Only devices inside the inclusive range receive tailored multi-image assets.
+
+## `#Constants`
+
+Declare theme constants, image bindings, and CSS variables.
+
+```css
+#Constants {
+    PopupDialogArrowBool: false;
+    sideMenuImage: "menu.png"; /* resolves in res/theme.css/menu.png/ */
+    --main-bg: #ececec;        /* CSS variable */
+}
+```
+
+* String values ending with `Image` create multi-image constants if an asset exists at `res/<cssfile>/<name>/` or as a background image elsewhere in the stylesheet.
+* Use constants for booleans, numbers, enums, and fallback font scaling (e.g. `defaultFontSizeInt`).
+
+## `Default`
+
+Set properties on the implicit base UIID that all other UIIDs derive from:
+
+```css
+Default {
+    font-family: "native:MainLight";
+    color: #202020;
+}
+```
+
+Define cross-theme defaults (fonts, colors) here instead of repeating them in each UIID.

--- a/src/main/resources/static/docs/css/snippets/button-states.css
+++ b/src/main/resources/static/docs/css/snippets/button-states.css
@@ -1,0 +1,14 @@
+PrimaryButton {
+    cn1-derive: Button;
+    background-color: #0052a3;
+    color: white;
+}
+
+PrimaryButton.pressed {
+    background-color: #003d78;
+}
+
+PrimaryButton.disabled {
+    background-color: #7ba8d9;
+    color: #f0f3f8;
+}

--- a/src/main/resources/static/docs/css/snippets/font-face.css
+++ b/src/main/resources/static/docs/css/snippets/font-face.css
@@ -1,0 +1,10 @@
+@font-face {
+    font-family: "Montserrat";
+    src: url(res/Montserrat-Regular.ttf);
+}
+
+Heading {
+    font-family: "Montserrat";
+    font-size: 4mm;
+    text-align: center;
+}

--- a/src/main/resources/static/docs/css/snippets/media-queries.css
+++ b/src/main/resources/static/docs/css/snippets/media-queries.css
@@ -1,0 +1,15 @@
+Label {
+    color: #202020;
+}
+
+@media platform-and {
+    Label { color: #0a8f08; }
+}
+
+@media platform-ios {
+    Label { color: #c62828; }
+}
+
+@media density-very-high, density-hd, density-2hd {
+    Label { font-size: 2.6mm; }
+}

--- a/src/main/resources/static/docs/css/snippets/round-border.css
+++ b/src/main/resources/static/docs/css/snippets/round-border.css
@@ -1,0 +1,8 @@
+Avatar {
+    border: 2px #3399ff cn1-round-border;
+    cn1-box-shadow-color: rgba(0, 0, 0, 0.25);
+    cn1-box-shadow-spread: 0.5mm;
+    cn1-box-shadow-h: 0;
+    cn1-box-shadow-v: 0.5mm;
+    cn1-box-shadow-blur: 1mm;
+}

--- a/src/main/resources/static/docs/css/snippets/theme-loader.java
+++ b/src/main/resources/static/docs/css/snippets/theme-loader.java
@@ -1,0 +1,9 @@
+Resources theme = Resources.openLayered("/theme");
+Form home = new Form("Home", BoxLayout.y());
+
+Button cta = new Button("Continue");
+cta.setUIID("MyPrimaryButton");
+cta.addActionListener(e -> Dialog.show("Clicked", "Primary action", "OK", null));
+
+home.addAll(new Label(theme.getImage("menu.png")), cta);
+home.show();

--- a/src/main/resources/static/docs/css/snippets/theme-template.css
+++ b/src/main/resources/static/docs/css/snippets/theme-template.css
@@ -1,0 +1,25 @@
+#Device {
+    min-resolution: 120dpi;
+    max-resolution: 480dpi;
+}
+
+#Constants {
+    defaultFontSizeInt: 18;
+    defaultDesktopFontSizeInt: 14;
+}
+
+Default {
+    font-family: "native:MainRegular";
+    color: #202020;
+}
+
+Button {
+    padding: 2mm 3mm;
+    border: 1pt solid #3366ff;
+    cn1-background-type: cn1-image-scaled-fill;
+    background: linear-gradient(0deg, #6fa8ff, #2a5cc6);
+}
+
+Button.pressed {
+    background-color: #204c9b;
+}


### PR DESCRIPTION
## Summary
- replace the single Codename One CSS guide with a css/ subdirectory of focused markdown topics
- add ready-to-copy CSS and Java snippets under css/snippets for quick reuse
- update CN1_Restrictions.md to point contributors to the new modular documentation set

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6909a1f8883318587edc698875e79