### PR TITLE
Refine CSS compiler service locking and cross-platform tests

### DIFF
--- a/src/main/java/com/codename1/server/mcp/controller/ToolsController.java
+++ b/src/main/java/com/codename1/server/mcp/controller/ToolsController.java
@@ -4,6 +4,8 @@ import com.codename1.server.mcp.dto.AutoFixRequest;
 import com.codename1.server.mcp.dto.AutoFixResponse;
 import com.codename1.server.mcp.dto.CompileRequest;
 import com.codename1.server.mcp.dto.CompileResponse;
+import com.codename1.server.mcp.dto.CssCompileRequest;
+import com.codename1.server.mcp.dto.CssCompileResponse;
 import com.codename1.server.mcp.dto.ExplainRequest;
 import com.codename1.server.mcp.dto.ExplainResponse;
 import com.codename1.server.mcp.dto.LintRequest;
@@ -13,6 +15,7 @@ import com.codename1.server.mcp.dto.ScaffoldRequest;
 import com.codename1.server.mcp.dto.ScaffoldResponse;
 import com.codename1.server.mcp.dto.SnippetsRequest;
 import com.codename1.server.mcp.dto.SnippetsResponse;
+import com.codename1.server.mcp.service.CssCompileService;
 import com.codename1.server.mcp.service.ExternalCompileService;
 import com.codename1.server.mcp.service.LintService;
 import com.codename1.server.mcp.service.ScaffoldService;
@@ -28,12 +31,14 @@ public class ToolsController {
     private static final Logger LOG = LoggerFactory.getLogger(ToolsController.class);
     private final LintService lint;
     private final ExternalCompileService compile;
+    private final CssCompileService cssCompile;
     private final ScaffoldService scaffold;
     private final SnippetService snippets;
 
-    public ToolsController(LintService l, ExternalCompileService c, ScaffoldService s, SnippetService sn) {
+    public ToolsController(LintService l, ExternalCompileService c, CssCompileService css, ScaffoldService s, SnippetService sn) {
         this.lint = l;
         this.compile = c;
+        this.cssCompile = css;
         this.scaffold = s;
         this.snippets = sn;
     }
@@ -48,6 +53,13 @@ public class ToolsController {
     public CompileResponse compile(@RequestBody CompileRequest req) {
         LOG.info("HTTP compile request received with {} files", req.files().size());
         return compile.compile(req);
+    }
+
+    @PostMapping(value="/cn1_compile_css", consumes=MediaType.APPLICATION_JSON_VALUE)
+    public CssCompileResponse compileCss(@RequestBody CssCompileRequest req) {
+        int fileCount = req.files() != null ? req.files().size() : 0;
+        LOG.info("HTTP CSS compile request received with {} files (input={})", fileCount, req.inputPath());
+        return cssCompile.compile(req);
     }
 
     @PostMapping(value="/cn1_scaffold_project", consumes=MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/com/codename1/server/mcp/dto/CssCompileRequest.java
+++ b/src/main/java/com/codename1/server/mcp/dto/CssCompileRequest.java
@@ -1,0 +1,6 @@
+package com.codename1.server.mcp.dto;
+
+import java.util.List;
+
+public record CssCompileRequest(List<FileEntry> files, String inputPath, String outputPath) {
+}

--- a/src/main/java/com/codename1/server/mcp/dto/CssCompileResponse.java
+++ b/src/main/java/com/codename1/server/mcp/dto/CssCompileResponse.java
@@ -1,0 +1,4 @@
+package com.codename1.server.mcp.dto;
+
+public record CssCompileResponse(boolean ok, String log) {
+}

--- a/src/main/java/com/codename1/server/mcp/service/CssCompileService.java
+++ b/src/main/java/com/codename1/server/mcp/service/CssCompileService.java
@@ -1,0 +1,231 @@
+package com.codename1.server.mcp.service;
+
+import com.codename1.server.mcp.dto.CssCompileRequest;
+import com.codename1.server.mcp.dto.CssCompileResponse;
+import com.codename1.server.mcp.dto.FileEntry;
+import com.codename1.server.mcp.tools.GlobalExtractor;
+import com.codename1.server.mcp.tools.Jdk8ManagerFromResource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Locale;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import com.codename1.server.mcp.util.OsUtils;
+
+@Service
+public class CssCompileService {
+    private static final Logger LOG = LoggerFactory.getLogger(CssCompileService.class);
+    private static final Pattern URL_PATTERN = Pattern.compile("url\\(([^)]+)\\)");
+    private static final byte[] STUB_PNG = Base64.getDecoder().decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/YoLYiQAAAAASUVORK5CYII=");
+    private static final byte[] STUB_JPEG = Base64.getDecoder().decode("/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////2wBDAf//////////////////////////////////////////////////////////////////////////////////////wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAf/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIQAxAAAAF+AP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAT8Af//EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQIBAT8Af//EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQMBAT8Af//Z");
+    private static final byte[] STUB_SVG = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"1\" height=\"1\"></svg>".getBytes(StandardCharsets.UTF_8);
+
+    private final GlobalExtractor extractor;
+    private final Jdk8ManagerFromResource jdk8;
+
+    private final Lock fontStubLock = new ReentrantLock();
+    private volatile byte[] fontStub;
+
+    public CssCompileService(GlobalExtractor extractor, Jdk8ManagerFromResource jdk8) {
+        this.extractor = extractor;
+        this.jdk8 = jdk8;
+    }
+
+    public CssCompileResponse compile(CssCompileRequest request) {
+        Objects.requireNonNull(request, "request");
+        try {
+            Path designerJar = extractor.ensureFile("/cn1libs/designer.jar");
+            Path javaBinary = jdk8.ensureJava8();
+
+            Path workDir = Files.createTempDirectory("cn1css-");
+            Path cssInput = null;
+            List<Path> cssFiles = new ArrayList<>();
+            try {
+                List<FileEntry> files = request.files() == null ? List.of() : request.files();
+                for (FileEntry entry : files) {
+                    Path resolved = safeResolve(workDir, entry.path());
+                    Path parent = resolved.getParent();
+                    if (parent != null) {
+                        Files.createDirectories(parent);
+                    }
+                    Files.writeString(resolved, entry.content(), StandardCharsets.UTF_8);
+                    if (entry.path().equals(request.inputPath())) {
+                        cssInput = resolved;
+                    }
+                    if (entry.path().toLowerCase(Locale.ENGLISH).endsWith(".css")) {
+                        cssFiles.add(resolved);
+                    }
+                }
+                if (cssFiles.isEmpty()) {
+                    throw new IOException("No CSS files supplied for compilation");
+                }
+
+                if (cssInput == null) {
+                    cssInput = cssFiles.isEmpty() ? null : cssFiles.get(0);
+                }
+                if (cssInput == null) {
+                    throw new IOException("No CSS input file provided");
+                }
+
+                String outputName = request.outputPath() != null && !request.outputPath().isBlank() ? request.outputPath() : "theme.res";
+                Path outputFile = safeResolve(workDir, outputName);
+                Files.deleteIfExists(outputFile);
+                Path outputParent = outputFile.getParent();
+                if (outputParent != null) {
+                    Files.createDirectories(outputParent);
+                }
+
+                Files.createDirectories(workDir.resolve("target"));
+
+                for (Path cssFile : cssFiles) {
+                    ensureCssResources(workDir, cssFile, designerJar);
+                }
+
+                List<String> command = new ArrayList<>();
+                if (OsUtils.isLinux()) {
+                    Path xvfb = OsUtils.locateOnPath("xvfb-run");
+                    if (xvfb == null) {
+                        throw new IOException("xvfb-run command not available on PATH");
+                    }
+                    command.add(xvfb.toString());
+                    command.add("-a");
+                }
+                command.add(javaBinary.toString());
+                command.add("-cp");
+                command.add(designerJar.toString());
+                command.add("com.codename1.designer.css.CN1CSSCLI");
+                command.add("-i");
+                command.add(cssInput.toString());
+                command.add("-o");
+                command.add(outputFile.toString());
+
+                LOG.info("Running CSS compiler: {}", command);
+                ProcessBuilder pb = new ProcessBuilder(command);
+                pb.directory(workDir.toFile());
+                pb.redirectErrorStream(true);
+                Process process = pb.start();
+                String log;
+                try (InputStream in = process.getInputStream()) {
+                    log = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+                }
+                int exit = process.waitFor();
+                boolean ok = exit == 0 && Files.exists(outputFile);
+                LOG.info("CSS compile finished with exitCode={} ok={}", exit, ok);
+                return new CssCompileResponse(ok, log);
+            } finally {
+                cleanup(workDir);
+            }
+        } catch (Exception e) {
+            LOG.error("CSS compile failed", e);
+            return new CssCompileResponse(false, e.toString());
+        }
+    }
+
+    private Path safeResolve(Path root, String relative) throws IOException {
+        Path resolved = root.resolve(relative).normalize();
+        if (!resolved.startsWith(root)) {
+            throw new IOException("Attempt to escape workspace for path " + relative);
+        }
+        return resolved;
+    }
+
+    private void ensureCssResources(Path workRoot, Path cssFile, Path designerJar) throws IOException {
+        String css = Files.readString(cssFile, StandardCharsets.UTF_8);
+        Matcher matcher = URL_PATTERN.matcher(css);
+        while (matcher.find()) {
+            String raw = matcher.group(1).trim();
+            if (raw.isEmpty()) continue;
+            if (raw.startsWith("data:")) continue;
+            if (raw.startsWith("#")) continue;
+            String cleaned = raw;
+            if ((cleaned.startsWith("\"") && cleaned.endsWith("\"")) || (cleaned.startsWith("'") && cleaned.endsWith("'"))) {
+                cleaned = cleaned.substring(1, cleaned.length() - 1);
+            }
+            if (cleaned.startsWith("http://") || cleaned.startsWith("https://")) continue;
+            Path cssParent = cssFile.getParent();
+            if (cssParent == null) {
+                cssParent = cssFile.getFileSystem().getPath("");
+            }
+            Path resolved = safeResolve(workRoot, cssParent.resolve(cleaned).toString());
+            if (Files.exists(resolved)) continue;
+            Path parent = resolved.getParent();
+            if (parent != null) {
+                Files.createDirectories(parent);
+            }
+            byte[] content = stubContentFor(cleaned, designerJar);
+            Files.write(resolved, content, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+        }
+    }
+
+    private byte[] stubContentFor(String path, Path designerJar) throws IOException {
+        String lower = path.toLowerCase(Locale.ENGLISH);
+        if (lower.endsWith(".png") || lower.endsWith(".gif")) {
+            return STUB_PNG;
+        }
+        if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) {
+            return STUB_JPEG;
+        }
+        if (lower.endsWith(".svg")) {
+            return STUB_SVG;
+        }
+        if (lower.endsWith(".ttf") || lower.endsWith(".otf")) {
+            return loadFontStub(designerJar);
+        }
+        return new byte[0];
+    }
+
+    private byte[] loadFontStub(Path designerJar) throws IOException {
+        byte[] cached = fontStub;
+        if (cached != null) {
+            return cached;
+        }
+        fontStubLock.lock();
+        try {
+            if (fontStub != null) {
+                return fontStub;
+            }
+            try (InputStream in = Files.newInputStream(designerJar);
+                 ZipInputStream zip = new ZipInputStream(in)) {
+                ZipEntry entry;
+                while ((entry = zip.getNextEntry()) != null) {
+                    if (!entry.isDirectory() && entry.getName().equals("com/codename1/impl/javase/Roboto-Regular.ttf")) {
+                        fontStub = zip.readAllBytes();
+                        return fontStub;
+                    }
+                }
+            }
+            throw new IOException("Failed to locate Roboto-Regular.ttf inside designer.jar");
+        } finally {
+            fontStubLock.unlock();
+        }
+    }
+
+    private void cleanup(Path dir) {
+        if (dir == null) return;
+        try {
+            Files.walk(dir)
+                    .sorted((a, b) -> b.compareTo(a))
+                    .forEach(path -> {
+                        try { Files.deleteIfExists(path); } catch (IOException ignored) {}
+                    });
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/src/main/java/com/codename1/server/mcp/util/OsUtils.java
+++ b/src/main/java/com/codename1/server/mcp/util/OsUtils.java
@@ -1,0 +1,45 @@
+package com.codename1.server.mcp.util;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Locale;
+
+public final class OsUtils {
+    private OsUtils() {
+    }
+
+    public static boolean isLinux() {
+        return osName().contains("linux");
+    }
+
+    public static boolean isWindows() {
+        return osName().contains("win");
+    }
+
+    public static boolean isMac() {
+        String name = osName();
+        return name.contains("mac") || name.contains("darwin");
+    }
+
+    public static Path locateOnPath(String binary) {
+        String path = System.getenv("PATH");
+        if (path == null || path.isBlank()) {
+            return null;
+        }
+        String separator = System.getProperty("path.separator");
+        for (String segment : path.split(separator)) {
+            if (segment == null || segment.isBlank()) {
+                continue;
+            }
+            Path candidate = Path.of(segment).resolve(binary);
+            if (Files.isExecutable(candidate)) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    private static String osName() {
+        return System.getProperty("os.name", "").toLowerCase(Locale.ENGLISH);
+    }
+}

--- a/src/test/java/com/codename1/server/mcp/service/CssCompileIntegrationTest.java
+++ b/src/test/java/com/codename1/server/mcp/service/CssCompileIntegrationTest.java
@@ -1,0 +1,93 @@
+package com.codename1.server.mcp.service;
+
+import com.codename1.server.mcp.dto.CssCompileRequest;
+import com.codename1.server.mcp.dto.FileEntry;
+import com.codename1.server.mcp.tools.GlobalExtractor;
+import com.codename1.server.mcp.tools.Jdk8ManagerFromResource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import com.codename1.server.mcp.util.OsUtils;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assumptions.*;
+
+class CssCompileIntegrationTest {
+    private static final Path SHARED_CACHE = Paths.get(System.getProperty("java.io.tmpdir"), "cn1-mcp-it-css");
+    private static final String LINUX_RESOURCE = "/cn1libs/OpenJDK8U-jdk_x64_linux_hotspot_8u462b08.tar.gz";
+    private static final String MAC_URL = "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jdk_x64_mac_hotspot_8u382b05.tar.gz";
+    private static final String WINDOWS_URL = "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u382-b05/OpenJDK8U-jdk_x64_windows_hotspot_8u382b05.zip";
+
+    Path cacheDir;
+    GlobalExtractor extractor;
+    Jdk8ManagerFromResource jdkMgr;
+
+    @BeforeAll
+    static void ensureSharedCache() throws Exception {
+        Files.createDirectories(SHARED_CACHE);
+    }
+
+    @BeforeEach
+    void setup() throws Exception {
+        cacheDir = SHARED_CACHE.resolve(safeOsName());
+        Files.createDirectories(cacheDir);
+        extractor = new GlobalExtractor(cacheDir.toString(), "css-it-v1");
+        assumeTrue(resourceExists("/cn1libs/designer.jar"), "designer.jar resource missing");
+        jdkMgr = new Jdk8ManagerFromResource(extractor, LINUX_RESOURCE, MAC_URL, WINDOWS_URL, "release");
+        if (OsUtils.isLinux()) {
+            assumeTrue(OsUtils.locateOnPath("xvfb-run") != null, "xvfb-run must be available on Linux test hosts");
+        }
+    }
+
+    @Test
+    void compilesValidCssWithResources() {
+        CssCompileService svc = new CssCompileService(extractor, jdkMgr);
+        String css = """
+                @font-face {
+                  font-family: 'Stub';
+                  src: url('res/StubFont.ttf');
+                }
+                .button {
+                  background-image: url('res/bg.png');
+                  border-radius: 3px;
+                }
+                """;
+        var req = new CssCompileRequest(List.of(new FileEntry("theme.css", css)), "theme.css", "theme.res");
+        var res = svc.compile(req);
+        assertTrue(res.ok(), () -> "CSS compile failed: \n" + res.log());
+        assertTrue(res.log().contains("Using stateless mode"));
+    }
+
+    @Test
+    void reportsUnsupportedButValidCss() {
+        CssCompileService svc = new CssCompileService(extractor, jdkMgr);
+        String css = """
+                .container {
+                  display: grid;
+                  grid-template-columns: 1fr 1fr;
+                }
+                """;
+        var req = new CssCompileRequest(List.of(new FileEntry("theme.css", css)), "theme.css", "theme.res");
+        var res = svc.compile(req);
+        assertTrue(res.ok(), () -> "CSS compile should succeed even if unsupported: \n" + res.log());
+        assertTrue(res.log().toLowerCase().contains("unsupported"), () -> "Expected unsupported warning in log: \n" + res.log());
+    }
+
+    private static boolean resourceExists(String path) {
+        try (InputStream in = CssCompileIntegrationTest.class.getResourceAsStream(path)) {
+            return in != null;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static String safeOsName() {
+        return System.getProperty("os.name", "generic").replaceAll("[^A-Za-z0-9]+", "-").toLowerCase();
+    }
+}


### PR DESCRIPTION
## Summary
- replace the `CssCompileService` font stub synchronization with an explicit lock and share OS helpers from a new `OsUtils`
- reuse the OS helpers when wiring the xvfb command and expose them for broader use
- run the CSS compilation integration tests on all platforms by provisioning the appropriate JDK archives and checking Linux prerequisites

## Testing
- ./mvnw test

------
https://chatgpt.com/codex/tasks/task_e_68e717e062f08331b24b1802776a896a