### PR TITLE
Refine native stub generator and documentation

### DIFF
--- a/src/main/java/com/codename1/server/mcp/controller/ToolsController.java
+++ b/src/main/java/com/codename1/server/mcp/controller/ToolsController.java
@@ -10,6 +10,8 @@ import com.codename1.server.mcp.dto.ExplainRequest;
 import com.codename1.server.mcp.dto.ExplainResponse;
 import com.codename1.server.mcp.dto.LintRequest;
 import com.codename1.server.mcp.dto.LintResponse;
+import com.codename1.server.mcp.dto.NativeStubRequest;
+import com.codename1.server.mcp.dto.NativeStubResponse;
 import com.codename1.server.mcp.dto.Patch;
 import com.codename1.server.mcp.dto.ScaffoldRequest;
 import com.codename1.server.mcp.dto.ScaffoldResponse;
@@ -18,6 +20,7 @@ import com.codename1.server.mcp.dto.SnippetsResponse;
 import com.codename1.server.mcp.service.CssCompileService;
 import com.codename1.server.mcp.service.ExternalCompileService;
 import com.codename1.server.mcp.service.LintService;
+import com.codename1.server.mcp.service.NativeStubService;
 import com.codename1.server.mcp.service.ScaffoldService;
 import com.codename1.server.mcp.service.SnippetService;
 import org.slf4j.Logger;
@@ -34,13 +37,15 @@ public class ToolsController {
     private final CssCompileService cssCompile;
     private final ScaffoldService scaffold;
     private final SnippetService snippets;
+    private final NativeStubService nativeStubs;
 
-    public ToolsController(LintService l, ExternalCompileService c, CssCompileService css, ScaffoldService s, SnippetService sn) {
+    public ToolsController(LintService l, ExternalCompileService c, CssCompileService css, ScaffoldService s, SnippetService sn, NativeStubService ns) {
         this.lint = l;
         this.compile = c;
         this.cssCompile = css;
         this.scaffold = s;
         this.snippets = sn;
+        this.nativeStubs = ns;
     }
 
     @PostMapping(value="/cn1_lint_code", consumes=MediaType.APPLICATION_JSON_VALUE)
@@ -92,5 +97,12 @@ public class ToolsController {
       + com.codename1.ui.Display.getInstance().callSerially(() -> { form.show(); });
       """);
         return new AutoFixResponse(patched, java.util.List.of(patch));
+    }
+
+    @PostMapping(value="/cn1_generate_native_stubs", consumes=MediaType.APPLICATION_JSON_VALUE)
+    public NativeStubResponse generateNativeStubs(@RequestBody NativeStubRequest req) {
+        int fileCount = req.files() != null ? req.files().size() : 0;
+        LOG.info("HTTP native stub generation request received for interface {} ({} source files)", req.interfaceName(), fileCount);
+        return nativeStubs.generate(req);
     }
 }

--- a/src/main/java/com/codename1/server/mcp/dto/NativeStubRequest.java
+++ b/src/main/java/com/codename1/server/mcp/dto/NativeStubRequest.java
@@ -1,0 +1,12 @@
+package com.codename1.server.mcp.dto;
+
+import java.util.List;
+
+/**
+ * Request payload for the native stub generation tool. The caller supplies the
+ * Java source files that make up the compilation unit (at minimum the native
+ * interface itself) along with the fully-qualified interface name that should
+ * be processed.
+ */
+public record NativeStubRequest(List<FileEntry> files, String interfaceName) {
+}

--- a/src/main/java/com/codename1/server/mcp/dto/NativeStubResponse.java
+++ b/src/main/java/com/codename1/server/mcp/dto/NativeStubResponse.java
@@ -1,0 +1,9 @@
+package com.codename1.server.mcp.dto;
+
+import java.util.List;
+
+/**
+ * Response payload containing the generated native stub source files.
+ */
+public record NativeStubResponse(List<FileEntry> files) {
+}

--- a/src/main/java/com/codename1/server/mcp/service/NativeStubGenerator.java
+++ b/src/main/java/com/codename1/server/mcp/service/NativeStubGenerator.java
@@ -1,0 +1,354 @@
+package com.codename1.server.mcp.service;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.IntStream;
+
+/**
+ * Port of the Codename One native stub generator that operates purely in
+ * memory. The implementation mirrors the behaviour of the Ant-based tooling in
+ * the Codename One build server so that agents can generate the boilerplate for
+ * all supported native platforms directly from the MCP.
+ */
+class NativeStubGenerator {
+    private static final String NATIVE_INTERFACE_FQN = "com.codename1.system.NativeInterface";
+
+    private final Class<?> nativeInterface;
+    private final List<Method> declaredMethods;
+
+    NativeStubGenerator(Class<?> nativeInterface) {
+        this.nativeInterface = nativeInterface;
+        this.declaredMethods = Arrays.stream(nativeInterface.getMethods())
+                .filter(m -> !m.getDeclaringClass().getName().equals(NATIVE_INTERFACE_FQN))
+                .toList();
+    }
+
+    String verify() {
+        if (!nativeInterface.isInterface()) {
+            return "Not an interface! Native interfaces must be interfaces.";
+        }
+
+        if (!isSubinterfaceOfNativeInterface(nativeInterface)) {
+            return "The interface MUST implement NativeInterface!";
+        }
+
+        if ((nativeInterface.getModifiers() & Modifier.PUBLIC) != Modifier.PUBLIC) {
+            return "The interface must be a public interface and not an inner class";
+        }
+
+        if (nativeInterface.getEnclosingClass() != null) {
+            return "The interface must be a public interface and not an inner class";
+        }
+
+        if (nativeInterface.getPackage() == null) {
+            return "The interface must declare a package";
+        }
+
+        Set<String> methodNames = new HashSet<>();
+        for (Method m : declaredMethods) {
+            String lowerCaseName = m.getName().toLowerCase(Locale.ROOT);
+            if (!methodNames.add(lowerCaseName)) {
+                return "A method with the same name exists for the method " + m.getName()
+                        + ", notice that duplicate names (even with different case) aren't supported!";
+            }
+
+            if (m.getExceptionTypes().length > 0) {
+                return "Exceptions aren't supported when communicating with native interfaces, in the method " + m.getName();
+            }
+
+            if (m.getName().equalsIgnoreCase("init")) {
+                return "init() is a reserved method in iOS (a constructor of sort) naming a method init will not work properly.";
+            }
+
+            if (!isValidType(m.getReturnType())) {
+                return "Unsupported return type  " + m.getReturnType().getSimpleName() + " in the method " + m.getName();
+            }
+
+            for (Class<?> arg : m.getParameterTypes()) {
+                if (!isValidType(arg)) {
+                    return "Unsupported argument type  " + arg.getSimpleName() + " in the method " + m.getName();
+                }
+            }
+        }
+
+        return null;
+    }
+
+    Map<String, String> generate() {
+        Map<String, String> files = new LinkedHashMap<>();
+        try {
+            addJavaFile(files, "android", "android.view.View", false);
+            addJavaFile(files, "javase", "com.codename1.ui.PeerComponent", true);
+            addJavaFile(files, "rim", "net.rim.device.api.ui.Field", false);
+            addJavaFile(files, "j2me", "Object", false);
+            addCSFile(files, "win", "FrameworkElement");
+            addIOSFiles(files);
+            addJavaScriptFile(files);
+        } catch (IOException ex) {
+            throw new UncheckedIOException(ex);
+        }
+        return files;
+    }
+
+    private void addJavaFile(Map<String, String> files, String platformDir, String peerComponentType, boolean impl) throws IOException {
+        String pkg = nativeInterface.getPackage().getName();
+        String className = nativeInterface.getSimpleName() + "Impl";
+        StringBuilder builder = new StringBuilder("package " + pkg + ";\n\n");
+        builder.append("public class ").append(className);
+        builder.append(impl ? " implements " + nativeInterface.getName() + "{\n" : " {\n");
+
+        for (Method m : declaredMethods) {
+            builder.append("    public ");
+            Class<?> returnType = m.getReturnType();
+            builder.append(returnType.getName().equals("com.codename1.ui.PeerComponent") ? peerComponentType : getJavaTypeName(returnType));
+            builder.append(' ').append(m.getName()).append('(');
+
+            Class<?>[] params = m.getParameterTypes();
+            builder.append(IntStream.range(0, params.length)
+                    .mapToObj(i -> {
+                        Class<?> arg = params[i];
+                        String typeName = arg.getName().equals("com.codename1.ui.PeerComponent") ? peerComponentType : getJavaTypeName(arg);
+                        return typeName + " param" + (i == 0 ? "" : Integer.toString(i));
+                    })
+                    .collect(java.util.stream.Collectors.joining(", ")));
+            builder.append(") {\n");
+
+            builder.append("        ").append(defaultReturnStatement(returnType));
+
+            builder.append("    }\n\n");
+        }
+        builder.append("}\n");
+
+        String path = platformDir + "/" + pkg.replace('.', '/') + "/" + className + ".java";
+        files.put(path, builder.toString());
+    }
+
+    private void addCSFile(Map<String, String> files, String platformDir, String peerComponentType) throws IOException {
+        String pkg = nativeInterface.getPackage().getName();
+        StringBuilder builder = new StringBuilder();
+        builder.append("namespace ").append(pkg).append("{\r\n\r\n");
+        builder.append("public class ").append(nativeInterface.getSimpleName()).append("Impl : I")
+                .append(nativeInterface.getSimpleName()).append("Impl {\r\n");
+
+        for (Method m : declaredMethods) {
+            builder.append("    public ");
+            builder.append(javaTypeToCSharpType(m.getReturnType()));
+            builder.append(' ').append(m.getName()).append('(');
+            Class<?>[] params = m.getParameterTypes();
+            builder.append(IntStream.range(0, params.length)
+                    .mapToObj(i -> {
+                        Class<?> arg = params[i];
+                        String typeName = switch (arg.getName()) {
+                            case "com.codename1.ui.PeerComponent" -> "object";
+                            default -> switch (arg) {
+                                case Class<?> t when t == boolean.class || t == Boolean.class || t == Boolean.TYPE -> "bool";
+                                default -> getJavaTypeName(arg);
+                            };
+                        };
+                        return typeName + " param" + (i == 0 ? "" : Integer.toString(i));
+                    })
+                    .collect(java.util.stream.Collectors.joining(", ")));
+            builder.append(") {\n");
+            builder.append("        ").append(defaultReturnStatement(m.getReturnType()));
+            builder.append("    }\n\n");
+        }
+        builder.append("}\r\n}\r\n");
+
+        String path = platformDir + "/" + pkg.replace('.', '/') + "/" + nativeInterface.getSimpleName() + "Impl.cs";
+        files.put(path, builder.toString());
+    }
+
+    private void addIOSFiles(Map<String, String> files) throws IOException {
+        String prefix = nativeInterface.getName().replace('.', '_') + "Impl";
+        StringBuilder header = new StringBuilder();
+        header.append("#import <Foundation/Foundation.h>\n\n");
+        header.append("@interface ").append(prefix).append(" : NSObject {\n}\n\n");
+        for (Method m : declaredMethods) {
+            header.append("-(").append(javaTypeToObjectiveCType(m.getReturnType())).append(')').append(m.getName());
+            Class<?>[] params = m.getParameterTypes();
+            if (params.length == 0) {
+                header.append(";\n");
+            } else {
+                header.append(":(").append(javaTypeToObjectiveCType(params[0])).append(")param");
+                if (params.length == 1) {
+                    header.append(";\n");
+                } else {
+                    for (int i = 1; i < params.length; i++) {
+                        header.append(" param").append(i).append(":(").append(javaTypeToObjectiveCType(params[i])).append(")param").append(i);
+                    }
+                    header.append(";\n");
+                }
+            }
+        }
+        header.append("@end\n");
+
+        StringBuilder impl = new StringBuilder();
+        impl.append("#import \"").append(prefix).append(".h\"\n\n");
+        impl.append("@implementation ").append(prefix).append("\n\n");
+
+        for (Method m : declaredMethods) {
+            impl.append("-(").append(javaTypeToObjectiveCType(m.getReturnType())).append(')').append(m.getName());
+            Class<?>[] params = m.getParameterTypes();
+            if (params.length == 0) {
+                impl.append("{\n");
+            } else {
+                impl.append(":(").append(javaTypeToObjectiveCType(params[0])).append(")param");
+                if (params.length == 1) {
+                    impl.append("{\n");
+                } else {
+                    for (int i = 1; i < params.length; i++) {
+                        impl.append(" param").append(i).append(":(").append(javaTypeToObjectiveCType(params[i])).append(")param").append(i);
+                    }
+                    impl.append("{\n");
+                }
+            }
+            impl.append("    ").append(defaultReturnStatement(m.getReturnType()));
+            impl.append("}\n\n");
+        }
+        impl.append("@end\n");
+
+        files.put("ios/" + prefix + ".h", header.toString());
+        files.put("ios/" + prefix + ".m", impl.toString());
+    }
+
+    private void addJavaScriptFile(Map<String, String> files) throws IOException {
+        StringBuilder builder = new StringBuilder();
+        builder.append("(function(exports){\n\n");
+        builder.append("var o = {};\n\n");
+
+        for (Method m : declaredMethods) {
+            builder.append("    o.").append(m.getName());
+            builder.append('_');
+            for (Class<?> param : m.getParameterTypes()) {
+                builder.append('_');
+                if (param.getName().equals("com.codename1.ui.PeerComponent")) {
+                    builder.append("com_codename1_ui_PeerComponent");
+                } else {
+                    builder.append(typeToXMLVMJavaName(param));
+                }
+            }
+            builder.append(" = function(");
+            Class<?>[] params = m.getParameterTypes();
+            if (params.length > 0) {
+                builder.append("param1");
+                for (int i = 1; i < params.length; i++) {
+                    builder.append(", param").append(i + 1);
+                }
+                builder.append(", callback) {\n");
+            } else {
+                builder.append("callback) {\n");
+            }
+
+            builder.append("        ");
+            builder.append(m.getName().equals("isSupported") ? "callback.complete(false);" : "callback.error(new Error(\"Not implemented yet\"));");
+            builder.append("\n");
+            builder.append("    };\n\n");
+        }
+        builder.append("exports.").append(nativeInterface.getName().replace('.', '_')).append("= o;\n\n");
+        builder.append("})(cn1_get_native_interfaces());\n");
+
+        files.put("javascript/" + nativeInterface.getName().replace('.', '_') + ".js", builder.toString());
+    }
+
+    private static boolean isSubinterfaceOfNativeInterface(Class<?> iface) {
+        for (Class<?> current : iface.getInterfaces()) {
+            if (current.getName().equals(NATIVE_INTERFACE_FQN)) {
+                return true;
+            }
+            if (isSubinterfaceOfNativeInterface(current)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static boolean isValidType(Class<?> cls) {
+        return switch (cls) {
+            case Class<?> type when type.isPrimitive() -> true;
+            case Class<?> type when type.isArray() -> type.getComponentType().isPrimitive();
+            case Class<?> type when type == String.class -> true;
+            case Class<?> type when type.getName().equals("com.codename1.ui.PeerComponent") -> true;
+            default -> false;
+        };
+    }
+
+    private static String defaultReturnStatement(Class<?> returnType) {
+        return switch (returnType) {
+            case Class<?> type when type == Void.TYPE || type == Void.class -> "// TODO implement\n";
+            case Class<?> type when type == String.class
+                    || type.getName().equals("com.codename1.ui.PeerComponent")
+                    || type.isArray() -> "return null;\n";
+            case Class<?> type when type == Boolean.class || type == Boolean.TYPE -> "return false;\n";
+            case Class<?> type when type == Character.class || type == Character.TYPE -> "return (char)0;\n";
+            case Class<?> type when type == Byte.class || type == Byte.TYPE -> "return (byte)0;\n";
+            case Class<?> type when type == Short.class || type == Short.TYPE -> "return (short)0;\n";
+            default -> "return 0;\n";
+        };
+    }
+
+    private static String getJavaTypeName(Class<?> type) {
+        if (type.isArray()) {
+            return getJavaTypeName(type.getComponentType()) + "[]";
+        }
+        return type.getSimpleName();
+    }
+
+    private static String javaTypeToObjectiveCType(Class<?> type) {
+        return switch (type) {
+            case Class<?> t when t == String.class -> "NSString*";
+            case Class<?> t when t.isArray() -> "NSData*";
+            case Class<?> t when t == Integer.class || t == Integer.TYPE -> "int";
+            case Class<?> t when t == Long.class || t == Long.TYPE -> "long long";
+            case Class<?> t when t == Byte.class || t == Byte.TYPE -> "char";
+            case Class<?> t when t == Short.class || t == Short.TYPE -> "short";
+            case Class<?> t when t == Character.class || t == Character.TYPE -> "int";
+            case Class<?> t when t == Boolean.class || t == Boolean.TYPE -> "BOOL";
+            case Class<?> t when t == Float.class || t == Float.TYPE -> "float";
+            case Class<?> t when t == Double.class || t == Double.TYPE -> "double";
+            case Class<?> t when t == Void.class || t == Void.TYPE -> "void";
+            default -> "void*";
+        };
+    }
+
+    private static String javaTypeToCSharpType(Class<?> type) {
+        return switch (type) {
+            case Class<?> t when t.getName().equals("com.codename1.ui.PeerComponent") -> "object";
+            case Class<?> t when t == String.class -> "string";
+            case Class<?> t when t.isArray() -> javaTypeToCSharpType(t.getComponentType()) + "[]";
+            case Class<?> t when t == Boolean.class || t == Boolean.TYPE -> "bool";
+            case Class<?> t when t == Character.class || t == Character.TYPE -> "char";
+            case Class<?> t when t == Byte.class || t == Byte.TYPE -> "byte";
+            case Class<?> t when t == Short.class || t == Short.TYPE -> "short";
+            case Class<?> t when t == Integer.class || t == Integer.TYPE -> "int";
+            case Class<?> t when t == Long.class || t == Long.TYPE -> "long";
+            case Class<?> t when t == Float.class || t == Float.TYPE -> "float";
+            case Class<?> t when t == Double.class || t == Double.TYPE -> "double";
+            case Class<?> t when t == Void.class || t == Void.TYPE -> "void";
+            default -> type.getSimpleName();
+        };
+    }
+
+    private static String typeToXMLVMJavaName(Class<?> type) {
+        return type.isArray()
+                ? getSimpleNameWithJavaLang(type.getComponentType()).replace('.', '_') + "_1ARRAY"
+                : getSimpleNameWithJavaLang(type).replace('.', '_');
+    }
+
+    private static String getSimpleNameWithJavaLang(Class<?> c) {
+        return switch (c) {
+            case Class<?> type when type.isPrimitive() -> type.getSimpleName();
+            case Class<?> type when type.isArray() -> getSimpleNameWithJavaLang(type.getComponentType()) + "[]";
+            case Class<?> type when type.getName().startsWith("java.lang.") -> type.getName();
+            default -> c.getSimpleName();
+        };
+    }
+}

--- a/src/main/java/com/codename1/server/mcp/service/NativeStubGenerator.java
+++ b/src/main/java/com/codename1/server/mcp/service/NativeStubGenerator.java
@@ -28,7 +28,7 @@ class NativeStubGenerator {
     NativeStubGenerator(Class<?> nativeInterface) {
         this.nativeInterface = nativeInterface;
         this.declaredMethods = Arrays.stream(nativeInterface.getMethods())
-                .filter(m -> !m.getDeclaringClass().getName().equals(NATIVE_INTERFACE_FQN))
+                .filter(m -> !m.getDeclaringClass().equals(Object.class))
                 .toList();
     }
 
@@ -211,7 +211,7 @@ class NativeStubGenerator {
                     impl.append("{\n");
                 }
             }
-            impl.append("    ").append(defaultReturnStatement(m.getReturnType()));
+            impl.append("    ").append(defaultObjectiveCReturnStatement(m.getReturnType()));
             impl.append("}\n\n");
         }
         impl.append("@end\n");
@@ -291,6 +291,16 @@ class NativeStubGenerator {
             case Class<?> type when type == Character.class || type == Character.TYPE -> "return (char)0;\n";
             case Class<?> type when type == Byte.class || type == Byte.TYPE -> "return (byte)0;\n";
             case Class<?> type when type == Short.class || type == Short.TYPE -> "return (short)0;\n";
+            default -> "return 0;\n";
+        };
+    }
+
+    private static String defaultObjectiveCReturnStatement(Class<?> returnType) {
+        return switch (returnType) {
+            case Class<?> type when type == Void.TYPE || type == Void.class -> "// TODO implement\n";
+            case Class<?> type when type == String.class || type.isArray() -> "return nil;\n";
+            case Class<?> type when type.getName().equals("com.codename1.ui.PeerComponent") -> "return NULL;\n";
+            case Class<?> type when type == Boolean.class || type == Boolean.TYPE -> "return NO;\n";
             default -> "return 0;\n";
         };
     }

--- a/src/main/java/com/codename1/server/mcp/service/NativeStubService.java
+++ b/src/main/java/com/codename1/server/mcp/service/NativeStubService.java
@@ -1,0 +1,140 @@
+package com.codename1.server.mcp.service;
+
+import com.codename1.server.mcp.dto.FileEntry;
+import com.codename1.server.mcp.dto.NativeStubRequest;
+import com.codename1.server.mcp.dto.NativeStubResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import javax.tools.DiagnosticCollector;
+import javax.tools.JavaCompiler;
+import javax.tools.JavaFileObject;
+import javax.tools.StandardJavaFileManager;
+import javax.tools.ToolProvider;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+@Service
+public class NativeStubService {
+    private static final Logger LOG = LoggerFactory.getLogger(NativeStubService.class);
+
+    public NativeStubResponse generate(NativeStubRequest request) {
+        Objects.requireNonNull(request, "request");
+        if (request.interfaceName() == null || request.interfaceName().isBlank()) {
+            throw new IllegalArgumentException("interfaceName is required");
+        }
+        if (request.files() == null || request.files().isEmpty()) {
+            throw new IllegalArgumentException("At least one source file is required");
+        }
+
+        JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+        if (compiler == null) {
+            throw new IllegalStateException("A JDK is required to generate native stubs");
+        }
+
+        Path sourceDir;
+        Path classesDir;
+        try {
+            sourceDir = Files.createTempDirectory("cn1-native-src");
+            classesDir = Files.createTempDirectory("cn1-native-classes");
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to allocate temporary workspace", e);
+        }
+
+        try {
+            Map<String, FileEntry> provided = new LinkedHashMap<>();
+            for (FileEntry entry : request.files()) {
+                Path dest = sourceDir.resolve(entry.path());
+                Files.createDirectories(dest.getParent());
+                Files.writeString(dest, entry.content(), StandardCharsets.UTF_8);
+                provided.put(entry.path(), entry);
+            }
+
+            ensureStub(sourceDir, provided, "com/codename1/system/NativeInterface.java",
+                    "package com.codename1.system;\n\npublic interface NativeInterface {\n    boolean isSupported();\n}\n");
+            ensureStub(sourceDir, provided, "com/codename1/ui/PeerComponent.java",
+                    "package com.codename1.ui;\n\npublic class PeerComponent { }\n");
+
+            List<Path> sources = new ArrayList<>();
+            try (var stream = Files.walk(sourceDir)) {
+                stream.filter(p -> p.toString().endsWith(".java")).forEach(sources::add);
+            }
+
+            DiagnosticCollector<JavaFileObject> diagnostics = new DiagnosticCollector<>();
+            try (StandardJavaFileManager fileManager = compiler.getStandardFileManager(diagnostics, Locale.ROOT, StandardCharsets.UTF_8)) {
+                Iterable<? extends JavaFileObject> compilationUnits = fileManager.getJavaFileObjectsFromPaths(sources);
+                List<String> options = List.of("-classpath", System.getProperty("java.class.path"), "-d", classesDir.toString());
+                JavaCompiler.CompilationTask task = compiler.getTask(null, fileManager, diagnostics, options, null, compilationUnits);
+                Boolean ok = task.call();
+                if (!Boolean.TRUE.equals(ok)) {
+                    StringBuilder message = new StringBuilder("Compilation failed:\n");
+                    diagnostics.getDiagnostics().forEach(d -> message.append(d.toString()).append('\n'));
+                    throw new IllegalArgumentException(message.toString());
+                }
+            }
+
+            try (URLClassLoader loader = new URLClassLoader(new URL[]{classesDir.toUri().toURL()}, getClass().getClassLoader())) {
+                Class<?> iface;
+                try {
+                    iface = Class.forName(request.interfaceName(), true, loader);
+                } catch (ClassNotFoundException e) {
+                    throw new IllegalArgumentException("Interface not found after compilation: " + request.interfaceName(), e);
+                }
+                NativeStubGenerator generator = new NativeStubGenerator(iface);
+                String validation = generator.verify();
+                if (validation != null) {
+                    throw new IllegalArgumentException(validation);
+                }
+                Map<String, String> generated = generator.generate();
+                LOG.info("Generated {} native stub files for interface {}", generated.size(), request.interfaceName());
+                List<FileEntry> files = generated.entrySet().stream()
+                        .sorted(Map.Entry.comparingByKey())
+                        .map(e -> new FileEntry(e.getKey(), e.getValue()))
+                        .toList();
+                return new NativeStubResponse(files);
+            }
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to generate native stubs", e);
+        } finally {
+            cleanup(sourceDir);
+            cleanup(classesDir);
+        }
+    }
+
+    private static void ensureStub(Path sourceDir, Map<String, FileEntry> provided, String relativePath, String content) throws IOException {
+        if (provided.containsKey(relativePath)) {
+            return;
+        }
+        Path dest = sourceDir.resolve(relativePath);
+        Files.createDirectories(dest.getParent());
+        Files.writeString(dest, content, StandardCharsets.UTF_8);
+    }
+
+    private static void cleanup(Path dir) {
+        if (dir == null) {
+            return;
+        }
+        try (var stream = Files.walk(dir)) {
+            stream.sorted(Comparator.reverseOrder())
+                    .forEach(path -> {
+                        try {
+                            Files.deleteIfExists(path);
+                        } catch (IOException ignored) {
+                        }
+                    });
+        } catch (IOException ignored) {
+        }
+    }
+}

--- a/src/main/resources/static/docs/CN1_NativeInterfaces.md
+++ b/src/main/resources/static/docs/CN1_NativeInterfaces.md
@@ -1,0 +1,10 @@
+# Codename One Native Interfaces
+
+This guide now lives in dedicated chapters:
+
+* [Overview](native-interfaces/Overview.md)
+* [Type Mapping](native-interfaces/TypeMapping.md)
+* [Generated Stub Samples](native-interfaces/PlatformStubs.md)
+* [Threading, Permissions, and Assets](native-interfaces/ThreadingAndPermissions.md)
+* [Callbacks from Native Code](native-interfaces/Callbacks.md)
+* [Using the MCP Tool](native-interfaces/Tooling.md)

--- a/src/main/resources/static/docs/native-interfaces/Callbacks.md
+++ b/src/main/resources/static/docs/native-interfaces/Callbacks.md
@@ -1,0 +1,39 @@
+# Callbacks from Native Code
+
+## Java-Based Platforms
+
+Android, Java SE, RIM, and Java ME use Java for the native layer. Call static Java callbacks directly:
+
+```java
+com.mycompany.NativeCallback.callback();
+com.mycompany.NativeCallback.callback("My Arg");
+```
+
+## Objective-C (iOS)
+
+Include the generated headers and call the mangled method name. The `CodenameOne_GLViewController.h` header defines macros for threading state.
+
+```objectivec
+#include "com_mycompany_NativeCallback.h"
+#include "CodenameOne_GLViewController.h"
+
+com_mycompany_NativeCallback_callback__(CN1_THREAD_GET_STATE_PASS_SINGLE_ARG);
+com_mycompany_NativeCallback_callback___int(CN1_THREAD_GET_STATE_PASS_ARG intValue);
+com_mycompany_NativeCallback_callback___java_lang_String(CN1_THREAD_GET_STATE_PASS_ARG fromNSString(CN1_THREAD_GET_STATE_PASS_ARG nsStringValue));
+```
+
+To return values, note the `_R_` suffix that encodes the return type:
+
+```objectivec
+com_mycompany_NativeCallback_callback___int_R_int(intValue);
+```
+
+## JavaScript
+
+The `$GLOBAL$` bridge exposes static Java methods to native JavaScript. Append `$async` when the target method uses Codename One threading primitives.
+
+```javascript
+this.$GLOBAL$.com_codename1_googlemaps_MapContainer.fireMapChangeEvent__int_int_double_double$async(mapId, zoom, lat, lon);
+```
+
+Your code **must** include the literal string `this.$GLOBAL$.package_Class.method` so the build server can detect and expose the callback.

--- a/src/main/resources/static/docs/native-interfaces/Overview.md
+++ b/src/main/resources/static/docs/native-interfaces/Overview.md
@@ -1,0 +1,37 @@
+# Codename One Native Interfaces Overview
+
+Codename One native interfaces expose platform APIs, third-party SDKs, and bespoke native UI widgets to Java code. The MCP server bundles a `cn1_generate_native_stubs` tool that validates a native interface and emits boilerplate implementations for every supported Codename One target.
+
+## Quick Start
+
+1. **Declare the interface** in your Codename One project:
+
+    ```java
+    package com.mycompany.myapp;
+
+    import com.codename1.system.NativeInterface;
+
+    public interface MyNative extends NativeInterface {
+        String helloWorld(String message);
+        boolean isSupported();
+    }
+    ```
+
+2. **Invoke the MCP tool** with the fully-qualified interface name and the source files that contain it.
+3. **Copy the generated stubs** into your project's `native/<platform>` folders and fill in the platform logic.
+4. **Call the interface** using `NativeLookup.create(MyNative.class)` from your Java code.
+
+## Interface Requirements
+
+Native interfaces must obey a strict signature subset so the code can be mapped across all platforms:
+
+* The type must be a `public`, top-level Java interface.
+* It must extend `com.codename1.system.NativeInterface`.
+* Method parameters and return types are limited to:
+  * Java primitives (`byte`, `boolean`, `char`, `short`, `int`, `long`, `float`, `double`).
+  * `String`.
+  * One-dimensional arrays of primitives.
+  * `com.codename1.ui.PeerComponent` for native peers.
+* Methods cannot throw checked or unchecked exceptions.
+* Avoid method overloading and the name `init` (reserved on iOS).
+* `hashCode`, `equals`, and `toString` will never be bridged to native code.

--- a/src/main/resources/static/docs/native-interfaces/PlatformStubs.md
+++ b/src/main/resources/static/docs/native-interfaces/PlatformStubs.md
@@ -1,0 +1,55 @@
+# Generated Stub Samples
+
+The MCP tool emits safe defaults that compile immediately. For the example `MyNative` interface shown in the overview, the Android stub looks like:
+
+```java
+package com.mycompany.myapp;
+
+public class MyNativeImpl {
+    public String helloWorld(String message) {
+        return null;
+    }
+
+    public boolean isSupported() {
+        return false;
+    }
+}
+```
+
+The Java SE build includes an `implements MyNative` clause. Objective-C receives header (`com_mycompany_myapp_MyNativeImpl.h`) and implementation (`.m`) files:
+
+```objectivec
+#import "com_mycompany_myapp_MyNativeImpl.h"
+
+@implementation com_mycompany_myapp_MyNativeImpl
+
+-(NSString*)helloWorld:(NSString*)message{
+    // TODO implement
+}
+
+-(BOOL)isSupported{
+    return NO;
+}
+
+@end
+```
+
+The JavaScript bridge follows the callback pattern:
+
+```javascript
+(function(exports){
+
+var o = {};
+
+    o.helloWorld__java_lang_String = function(param1, callback) {
+        callback.error(new Error("Not implemented yet"));
+    };
+
+    o.isSupported_ = function(callback) {
+        callback.complete(false);
+    };
+
+exports.com_mycompany_myapp_MyNative = o;
+
+})(cn1_get_native_interfaces());
+```

--- a/src/main/resources/static/docs/native-interfaces/ThreadingAndPermissions.md
+++ b/src/main/resources/static/docs/native-interfaces/ThreadingAndPermissions.md
@@ -1,0 +1,21 @@
+# Threading, Permissions, and Assets
+
+## Threading Guidelines
+
+* **Android** – Use `AndroidNativeUtil.getActivity().runOnUiThread(...)` for asynchronous UI work or `AndroidImplementation.runOnUiThreadAndBlock(...)` when you need to block the Codename One EDT.
+* **iOS** – Wrap UI calls with `dispatch_async(dispatch_get_main_queue(), ^{ … })` (or `dispatch_sync` for blocking scenarios, being mindful of deadlocks).
+* **JavaScript** – Always reply through the provided callback. Omitting `callback.complete()` or `callback.error()` will deadlock the calling Java thread.
+
+## Permissions, Assets, and Build Hints
+
+Native Android code may need additional manifest permissions. Declare them with build hints such as:
+
+```
+android.permission.CAMERA=true
+android.permission.ACCESS_FINE_LOCATION.required=false
+android.permission.READ_CALENDAR.maxSdkVersion=28
+```
+
+Alternatively inject raw XML using `android.xpermissions=<uses-permission android:name="android.permission.READ_CALENDAR" />`.
+
+Native libraries (`.jar`, `.a`, etc.) should be placed inside the relevant `native/<platform>` folder so the build server packages them automatically.

--- a/src/main/resources/static/docs/native-interfaces/Tooling.md
+++ b/src/main/resources/static/docs/native-interfaces/Tooling.md
@@ -1,0 +1,20 @@
+# Using the MCP Tool
+
+Invoke the MCP tool with a payload similar to:
+
+```json
+{
+  "tool": "cn1_generate_native_stubs",
+  "arguments": {
+    "qualifiedInterfaceName": "com.mycompany.myapp.MyNative",
+    "sources": [
+      {
+        "path": "src/com/mycompany/myapp/MyNative.java",
+        "content": "..."
+      }
+    ]
+  }
+}
+```
+
+The response contains a `files` array whose entries provide the relative path and text content for each generated stub. Save them into your project, implement the platform logic, and rebuild your Codename One app.

--- a/src/main/resources/static/docs/native-interfaces/TypeMapping.md
+++ b/src/main/resources/static/docs/native-interfaces/TypeMapping.md
@@ -1,0 +1,26 @@
+# Native Interface Type Mapping
+
+Codename One limits native interface signatures so parameters and return values can be translated across platform toolchains. The table below summarizes how each supported Java type maps to the Android, Java SE, iOS, and Windows implementations.
+
+| Java Type       | Android             | Java SE              | iOS / Objective-C        | Windows (C#)     |
+|-----------------|---------------------|----------------------|--------------------------|------------------|
+| `byte`          | `byte`              | `byte`               | `char`                   | `sbyte`          |
+| `boolean`       | `boolean`           | `boolean`            | `BOOL`                   | `bool`           |
+| `char`          | `char`              | `char`               | `int`                    | `char`           |
+| `short`         | `short`             | `short`              | `short`                  | `short`          |
+| `int`           | `int`               | `int`                | `int`                    | `int`            |
+| `long`          | `long`              | `long`               | `long long`              | `long`           |
+| `float`         | `float`             | `float`              | `float`                  | `float`          |
+| `double`        | `double`            | `double`             | `double`                 | `double`         |
+| `String`        | `String`            | `String`             | `NSString*`              | `string`         |
+| `byte[]`        | `byte[]`            | `byte[]`             | `NSData*`                | `sbyte[]`        |
+| `boolean[]`     | `boolean[]`         | `boolean[]`          | `NSData*`                | `bool[]`         |
+| `char[]`        | `char[]`            | `char[]`             | `NSData*`                | `char[]`         |
+| `short[]`       | `short[]`           | `short[]`            | `NSData*`                | `short[]`        |
+| `int[]`         | `int[]`             | `int[]`              | `NSData*`                | `int[]`          |
+| `long[]`        | `long[]`            | `long[]`             | `NSData*`                | `long[]`         |
+| `float[]`       | `float[]`           | `float[]`            | `NSData*`                | `float[]`        |
+| `double[]`      | `double[]`          | `double[]`           | `NSData*`                | `double[]`       |
+| `PeerComponent` | `android.view.View` | `PeerComponent`      | `void*` (expect `UIView*`) | `FrameworkElement` |
+
+JavaScript bridges are dynamically typed. The generated bridge uses XMLVM-style naming and delivers results via callbacks (`callback.complete(value)` / `callback.error(error)`).

--- a/src/test/java/com/codename1/server/mcp/service/NativeStubServiceTest.java
+++ b/src/test/java/com/codename1/server/mcp/service/NativeStubServiceTest.java
@@ -1,0 +1,62 @@
+package com.codename1.server.mcp.service;
+
+import com.codename1.server.mcp.dto.FileEntry;
+import com.codename1.server.mcp.dto.NativeStubRequest;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class NativeStubServiceTest {
+
+    private final NativeStubService service = new NativeStubService();
+
+    @Test
+    void generatesStubsForValidInterface() {
+        String src = """
+                package com.mycompany.myapp;
+
+                import com.codename1.system.NativeInterface;
+
+                public interface MyNative extends NativeInterface {
+                    String helloWorld(String hi);
+                    int add(int a, int b);
+                }
+                """;
+
+        var request = new NativeStubRequest(List.of(new FileEntry("com/mycompany/myapp/MyNative.java", src)),
+                "com.mycompany.myapp.MyNative");
+
+        var response = service.generate(request);
+        assertEquals(8, response.files().size());
+        assertTrue(response.files().stream().anyMatch(f -> f.path().equals("android/com/mycompany/myapp/MyNativeImpl.java")));
+        assertTrue(response.files().stream().anyMatch(f -> f.path().equals("ios/com_mycompany_myapp_MyNativeImpl.h")));
+
+        var androidStub = response.files().stream()
+                .filter(f -> f.path().equals("android/com/mycompany/myapp/MyNativeImpl.java"))
+                .findFirst()
+                .orElseThrow();
+        assertTrue(androidStub.content().contains("return null;"));
+        assertTrue(androidStub.content().contains("return 0;"));
+    }
+
+    @Test
+    void rejectsInvalidTypes() {
+        String src = """
+                package com.mycompany.bad;
+
+                import com.codename1.system.NativeInterface;
+
+                public interface BadNative extends NativeInterface {
+                    java.util.Date nope();
+                }
+                """;
+
+        var request = new NativeStubRequest(List.of(new FileEntry("com/mycompany/bad/BadNative.java", src)),
+                "com.mycompany.bad.BadNative");
+
+        IllegalArgumentException ex = assertThrows(IllegalArgumentException.class, () -> service.generate(request));
+        assertTrue(ex.getMessage().contains("Unsupported return type"));
+    }
+}


### PR DESCRIPTION
## Summary
- modernize the native stub generator with Java 21 constructs, method filtering, and cleaner default handling
- expand the Codename One native interface guide with detailed type mappings, platform samples, threading and callback guidance
- split the native interface guide into modular chapters for easier browsing

## Testing
- `mvn -q test`


------
https://chatgpt.com/codex/tasks/task_e_68e7e340f8c88331a244eb0e9a3d37df