### PR TITLE
Emphasize build hint storage requirements and drop legacy snippet

### DIFF
--- a/src/main/java/com/codename1/server/mcp/service/SnippetService.java
+++ b/src/main/java/com/codename1/server/mcp/service/SnippetService.java
@@ -5,39 +5,34 @@ import com.codename1.server.mcp.dto.Snippet;
 import com.codename1.server.mcp.dto.SnippetsResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.stereotype.Service;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 public class SnippetService {
     private static final Logger LOG = LoggerFactory.getLogger(SnippetService.class);
-    private static final Map<String, List<Snippet>> DB = Map.of(
-            "rest", List.of(new Snippet("REST GET",
-                    "Use Rest with async onComplete; no blocking on EDT.",
-                    """
-                    import com.codename1.io.rest.*;
-                    Rest.get("https://api.example.com/items")
-                        .acceptJson()
-                        .onComplete(res -> {
-                          // This runs off EDT; update UI via callSerially
-                          com.codename1.ui.Display.getInstance().callSerially(() -> {
-                             // update UI
-                          });
-                        }).send();
-                    """)),
-                "storage", List.of(new Snippet("Storage save/read",
-                                                       "Use Storage or FileSystemStorage.",
-                                                       """
-                  import com.codename1.io.Storage;
-                  byte[] data = "hello".getBytes();
-                  Storage.getInstance().writeObject("greeting", data);
-                  byte[] out = (byte[]) Storage.getInstance().readObject("greeting");
-                  """))
-            );
+    private final Map<String, List<Snippet>> db;
+
+    public SnippetService(ResourcePatternResolver resolver) {
+        this.db = loadSnippets(resolver);
+        LOG.info("Loaded {} snippet topics from classpath", db.size());
+    }
 
     public SnippetsResponse get(String topic) {
-        var snippets = DB.getOrDefault(topic, List.of());
+        var snippets = db.getOrDefault(normalize(topic), List.of());
         LOG.info("Fetching snippets for topic {} -> {} matches", topic, snippets.size());
         return new SnippetsResponse(snippets);
     }
@@ -54,9 +49,96 @@ public class SnippetService {
                     "import javax.swing.JButton; new JButton();",
                     "import com.codename1.ui.Button; new Button();"
             );
-            default -> new ExplainResponse("No summary for "+ruleId, "", "");
+            default -> new ExplainResponse("No summary for " + ruleId, "", "");
         };
         LOG.info("Explain lookup for rule {} -> summaryLength={}", ruleId, response.summary().length());
         return response;
+    }
+
+    private Map<String, List<Snippet>> loadSnippets(ResourcePatternResolver resolver) {
+        var map = new LinkedHashMap<String, List<Snippet>>();
+        try {
+            Resource[] resources = resolver.getResources("classpath*:static/docs/snippets/**/*.md");
+            Arrays.sort(resources, (a, b) -> {
+                try {
+                    return a.getURL().toString().compareTo(b.getURL().toString());
+                } catch (IOException e) {
+                    return a.getFilename().compareTo(b.getFilename());
+                }
+            });
+
+            for (Resource resource : resources) {
+                parseResource(resource).ifPresent(entry -> {
+                    var topicKey = normalize(entry.topic);
+                    map.computeIfAbsent(topicKey, k -> new ArrayList<>())
+                            .add(entry.snippet);
+                });
+            }
+        } catch (IOException e) {
+            LOG.error("Failed to enumerate snippet resources", e);
+        }
+        return map;
+    }
+
+    private record SnippetEntry(String topic, Snippet snippet) {}
+
+    private java.util.Optional<SnippetEntry> parseResource(Resource resource) {
+        try (var reader = new BufferedReader(new InputStreamReader(resource.getInputStream(), StandardCharsets.UTF_8))) {
+            var raw = reader.lines().collect(Collectors.joining("\n"));
+            raw = stripBom(raw);
+            var normalized = raw.replace("\r\n", "\n").trim();
+            if (!normalized.startsWith("---\n")) {
+                LOG.warn("Snippet {} is missing front matter", resource.getFilename());
+                return java.util.Optional.empty();
+            }
+            int end = normalized.indexOf("\n---\n");
+            if (end < 0) {
+                LOG.warn("Snippet {} front matter is not terminated", resource.getFilename());
+                return java.util.Optional.empty();
+            }
+            String frontMatter = normalized.substring(4, end);
+            String body = normalized.substring(end + 5).trim();
+            var metadata = parseFrontMatter(frontMatter);
+            var topic = metadata.get("topic");
+            var title = metadata.get("title");
+            var description = metadata.get("description");
+            if (topic == null || title == null || description == null) {
+                LOG.warn("Snippet {} missing required metadata (topic/title/description)", resource.getFilename());
+                return java.util.Optional.empty();
+            }
+            return java.util.Optional.of(new SnippetEntry(topic, new Snippet(title, description, body)));
+        } catch (IOException e) {
+            LOG.warn("Failed to parse snippet {}", resource.getFilename(), e);
+            return java.util.Optional.empty();
+        }
+    }
+
+    private Map<String, String> parseFrontMatter(String frontMatter) {
+        var metadata = new LinkedHashMap<String, String>();
+        for (String line : frontMatter.split("\n")) {
+            var trimmed = line.trim();
+            if (trimmed.isEmpty() || trimmed.startsWith("#")) {
+                continue;
+            }
+            int sep = trimmed.indexOf(':');
+            if (sep < 0) {
+                continue;
+            }
+            String key = trimmed.substring(0, sep).trim().toLowerCase(Locale.ROOT);
+            String value = trimmed.substring(sep + 1).trim();
+            metadata.put(key, value);
+        }
+        return metadata;
+    }
+
+    private String stripBom(String text) {
+        if (text.startsWith("\uFEFF")) {
+            return text.substring(1);
+        }
+        return text;
+    }
+
+    private String normalize(String topic) {
+        return topic == null ? "" : topic.trim().toLowerCase(Locale.ROOT);
     }
 }

--- a/src/main/resources/static/docs/CN1_NativeInterfaces.md
+++ b/src/main/resources/static/docs/CN1_NativeInterfaces.md
@@ -6,5 +6,6 @@ This guide now lives in dedicated chapters:
 * [Type Mapping](native-interfaces/TypeMapping.md)
 * [Generated Stub Samples](native-interfaces/PlatformStubs.md)
 * [Threading, Permissions, and Assets](native-interfaces/ThreadingAndPermissions.md)
+* [Build Hints for Native Interfaces](native-interfaces/BuildHints.md)
 * [Callbacks from Native Code](native-interfaces/Callbacks.md)
 * [Using the MCP Tool](native-interfaces/Tooling.md)

--- a/src/main/resources/static/docs/native-interfaces/BuildHints.md
+++ b/src/main/resources/static/docs/native-interfaces/BuildHints.md
@@ -1,0 +1,62 @@
+# Build Hints for Native Interfaces
+
+Codename One "build hints" fine-tune the binaries that the build server emits. They let you
+request extra permissions, tweak manifest entries, and inject iOS `Info.plist`
+keys without writing auxiliary native build scripts. Native interface projects
+rely on build hints to connect Objective-C/Swift, Android, and JavaScript code to
+the correct system APIs at runtime.
+
+## Setting Build Hints
+
+* **Codename One Settings UI** – Choose **Codename One → Codename One Settings → Build Hints** to edit
+  key/value pairs interactively.
+* **`codenameone_settings.properties`** – Add properties that start with the
+  `codename1.arg.` prefix. For example, the UI value `android.permission.CAMERA=true`
+  becomes `codename1.arg.android.permission.CAMERA=true` when stored directly in
+  the properties file.
+
+> **Important:** Build hints only take effect when they are persisted in your
+> project's root `codenameone_settings.properties` file (prefixed with
+> `codename1.arg.`) or saved through the Codename One Settings UI, which writes
+> to the same location.
+
+Codename One applies the hints at build time across the supported targets. The
+Android pipeline consumes entries that start with `android.`; iOS reads `ios.`
+keys; desktop and JavaScript targets each have their own namespaces.
+
+## Common Native Integrations
+
+```properties
+# Request additional Android permissions
+android.permission.CAMERA=true
+android.permission.ACCESS_FINE_LOCATION.required=false
+
+# Supply iOS privacy descriptions
+ios.NSCameraUsageDescription=Capture profile photos inside the app.
+ios.NSMicrophoneUsageDescription=Record voice notes for sharing.
+
+# Link extra native libraries
+ios.add_libs=libsqlite3.dylib;libz.dylib
+android.xapplication=<service android:name="com.example.Service" />
+```
+
+Consult the [Codename One developer guide](https://www.codenameone.com/developer-guide.html#_build_hints)
+for the continually updated catalogue of options.
+
+## MCP Support for Build Hints
+
+The MCP server includes convenience snippets so you can bootstrap manifests and
+privacy descriptions while chatting with the agent. Ask for the `build-hints`
+snippet topic to retrieve ready-to-paste key/value pairs grouped by platform:
+
+* **Android** – core pipeline toggles, manifest injections, Play Services and ads,
+  push delivery, and device integrity checks.
+* **iOS** – build/distribution metadata, privacy entitlements, UI behavior, and
+  native code/Info.plist injection samples.
+* **JavaScript & Desktop** – proxy settings, HTML head injection, desktop window
+  sizing, bundled JVM selection, and macOS/Windows manifest tweaks.
+* **Global** – Google Play/AdMob keys, analytics opt-out, and other
+  cross-platform flags.
+
+Each snippet file mirrors the keys in the developer guide so you can copy an
+entire category directly into `codenameone_settings.properties`.

--- a/src/main/resources/static/docs/native-interfaces/Overview.md
+++ b/src/main/resources/static/docs/native-interfaces/Overview.md
@@ -20,6 +20,7 @@ Codename One native interfaces expose platform APIs, third-party SDKs, and bespo
 2. **Invoke the MCP tool** with the fully-qualified interface name and the source files that contain it.
 3. **Copy the generated stubs** into your project's `native/<platform>` folders and fill in the platform logic.
 4. **Call the interface** using `NativeLookup.create(MyNative.class)` from your Java code.
+5. **Add build hints** for any extra permissions, entitlements, or manifest tweaks required by the native code. See [Build Hints for Native Interfaces](BuildHints.md).
 
 ## Interface Requirements
 

--- a/src/main/resources/static/docs/native-interfaces/ThreadingAndPermissions.md
+++ b/src/main/resources/static/docs/native-interfaces/ThreadingAndPermissions.md
@@ -17,5 +17,7 @@ android.permission.READ_CALENDAR.maxSdkVersion=28
 ```
 
 Alternatively inject raw XML using `android.xpermissions=<uses-permission android:name="android.permission.READ_CALENDAR" />`.
+See [Build Hints for Native Interfaces](BuildHints.md) for additional targets and formatting
+guidelines.
 
 Native libraries (`.jar`, `.a`, etc.) should be placed inside the relevant `native/<platform>` folder so the build server packages them automatically.

--- a/src/main/resources/static/docs/native-interfaces/Tooling.md
+++ b/src/main/resources/static/docs/native-interfaces/Tooling.md
@@ -18,3 +18,22 @@ Invoke the MCP tool with a payload similar to:
 ```
 
 The response contains a `files` array whose entries provide the relative path and text content for each generated stub. Save them into your project, implement the platform logic, and rebuild your Codename One app.
+
+## Fetch Build Hint Examples
+
+Ask the MCP server for build hint suggestions with the snippets endpoint:
+
+```json
+{
+  "tool": "cn1_search_snippets",
+  "arguments": {
+    "topic": "build-hints"
+  }
+}
+```
+
+The reply lists ready-made key/value pairs you can paste into Codename One Settings
+or `codenameone_settings.properties` to configure permissions, privacy strings,
+and other manifest tweaks. The topic aggregates every markdown file in
+`static/docs/snippets`, so Android, iOS, desktop, JavaScript, and legacy
+categories all arrive in a single response for quick reference.

--- a/src/main/resources/static/docs/snippets/build-hints-android-core.md
+++ b/src/main/resources/static/docs/snippets/build-hints-android-core.md
@@ -1,0 +1,51 @@
+---
+topic: build-hints
+title: Core Android build hints
+description: Toggle Android build variants, SDK targeting, ProGuard, multidex, and runtime behaviors.
+---
+```properties
+# Control debug/release artifacts
+android.debug=true
+android.release=true
+
+# Deployment targeting
+android.installLocation=auto
+android.min_sdk_version=7
+android.targetSDKVersion=21
+android.versionCode=1
+
+# Build pipeline controls
+android.gradle=true
+android.multidex=false
+android.enableProguard=true
+android.shrinkResources=false
+android.proguardKeep=-keep class com.example.MyClass { *; }
+android.stack_size=1048576
+android.supportV4=false
+
+# Play Services version negotiation
+android.playServicesVersion=default
+mylib.minPlayServicesVersion=10.0.0
+
+# AndroidX toggle
+android.useAndroidX=true
+
+# Lifecycle/behavior flags
+android.keyboardOpen=true
+android.asyncPaint=true
+android.streamMode=music
+android.theme=Light
+android.statusbar_hidden=false
+android.web_loading_hidden=false
+android.captureRecord=enabled
+android.nonconsumable=premium_upgrade,extra_storage
+android.headphoneCallback=false
+android.gpsPermission=true
+android.mockLocation=true
+android.smallScreens=true
+android.removeBasePermissions=false
+android.blockExternalStoragePermission=false
+android.sharedUserId=com.example.shared
+android.sharedUserLabel=Shared Account
+android.licenseKey=YOUR_GOOGLE_PLAY_LICENSE
+```

--- a/src/main/resources/static/docs/snippets/build-hints-android-manifest.md
+++ b/src/main/resources/static/docs/snippets/build-hints-android-manifest.md
@@ -1,0 +1,37 @@
+---
+topic: build-hints
+title: Android manifest injection hints
+description: Inject permissions, attributes, and XML fragments into the generated Android manifest and resources.
+---
+```properties
+# Granular permission control
+android.permission.CAMERA=true
+android.permission.ACCESS_FINE_LOCATION.required=false
+android.permission.RECORD_AUDIO.maxSdkVersion=30
+
+# Bulk permission overrides
+android.xpermissions=<uses-permission android:name="android.permission.NFC" />
+
+# Intent filters for main activity
+android.xintent_filter=<intent-filter>...</intent-filter>
+
+# Activity launch mode override
+android.activity.launchMode=singleTask
+
+# Application and activity attribute injection
+android.xapplication=<service android:name="com.example.SyncService" />
+android.xapplication_attr=android:usesCleartextTraffic="true"
+android.xactivity=android:exported="true"
+
+# Manifest queries for Android 11+
+android.manifest.queries=<package android:name="com.example.app" />
+
+# Resource file injections
+android.stringsXml=<string name="greeting">Hello</string>
+android.style=<item name="android:windowTranslucentStatus">true</item>
+android.cusom_layout1=<LinearLayout ... />
+
+# Push and account configuration
+android.pushVibratePattern=0,250,100,250
+android.facebook_permissions=email,user_friends
+```

--- a/src/main/resources/static/docs/snippets/build-hints-android-play-services.md
+++ b/src/main/resources/static/docs/snippets/build-hints-android-play-services.md
@@ -1,0 +1,40 @@
+---
+topic: build-hints
+title: Android Play Services and ads hints
+description: Select specific Google Play Services artifacts and configure AdMob identifiers for Android builds.
+---
+```properties
+# Legacy toggle (prefer per-service flags below)
+android.includeGPlayServices=false
+
+# Enable only the services you need
+android.playService.base=true
+android.playService.location=true
+android.playService.maps=true
+android.playService.ads=true
+android.playService.plus=false
+android.playService.auth=false
+android.playService.analytics=false
+android.playService.cast=false
+android.playService.gcm=false
+android.playService.drive=false
+android.playService.fitness=false
+android.playService.vision=false
+android.playService.nearby=false
+android.playService.panorama=false
+android.playService.games=false
+android.playService.safetynet=false
+android.playService.wallet=false
+android.playService.wearable=false
+android.playService.identity=false
+android.playService.indexing=false
+android.playService.appInvite=false
+
+# Specify a concrete Play Services version (advanced)
+android.playServicesVersion=17.0.0
+
+# Provide your AdMob configuration
+google.adUnitId=ca-app-pub-XXXXXXXXXXXXXXXX/banner
+android.googleAdUnitId=ca-app-pub-XXXXXXXXXXXXXXXX/banner
+android.googleAdUnitTestDevice=C6783E2486F0931D9D09FABC65094FDF
+```

--- a/src/main/resources/static/docs/snippets/build-hints-android-push.md
+++ b/src/main/resources/static/docs/snippets/build-hints-android-push.md
@@ -1,0 +1,17 @@
+---
+topic: build-hints
+title: Android push and social hints
+description: Configure Android push background handling and native Facebook integration credentials.
+---
+```properties
+# Deliver push while app is backgrounded
+android.background_push_handling=true
+
+# Google Cloud Messaging / FCM sender id
+gcm.sender_id=1234567890
+
+# Facebook native integration
+facebook.appId=YOUR_FB_APP_ID
+facebook.clientToken=YOUR_FB_CLIENT_TOKEN
+android.facebook_permissions=email,user_friends
+```

--- a/src/main/resources/static/docs/snippets/build-hints-android-security.md
+++ b/src/main/resources/static/docs/snippets/build-hints-android-security.md
@@ -1,0 +1,23 @@
+---
+topic: build-hints
+title: Android integrity and security hints
+description: Detect rooted devices, block instrumentation, and tune signing schemes for Android builds.
+---
+```properties
+# Enable Google Play licensing and signing
+android.licenseKey=YOUR_GOOGLE_PLAY_LICENSE
+android.signingV1=true
+android.signingV2=true
+android.signingV3=true
+android.signingV4=true
+
+# Device integrity checks
+android.rootCheck=false
+android.fridaDetection=false
+android.fridaVersion=1.0.0
+android.fridaDebugLogging=false
+
+# Mock location and headphone callbacks
+android.mockLocation=true
+android.headphoneCallback=false
+```

--- a/src/main/resources/static/docs/snippets/build-hints-desktop.md
+++ b/src/main/resources/static/docs/snippets/build-hints-desktop.md
@@ -1,0 +1,36 @@
+---
+topic: build-hints
+title: Desktop build hints
+description: Size Codename One desktop apps, select bundled JVMs, and inject native desktop manifest values.
+---
+```properties
+# Window dimensions and behavior
+desktop.width=800
+desktop.height=600
+desktop.adaptToRetina=true
+desktop.resizable=true
+
+# Desktop themes
+desktop.theme=native
+desktop.themeMac=ios
+desktop.themeWin=win
+
+# High level packaging
+desktop.windowsOutput=exe
+
+# Mac/Windows media backends
+desktop.win.cef=false
+desktop.mac.cef=false
+
+# macOS Info.plist injection
+desktop.mac.plist.LSApplicationCategoryType=public.app-category.business
+desktop.mac.plistInject=<key>LSBackgroundOnly</key><true/>
+
+# Windows manifest extensions
+windows.extensions=<Extensions>...</Extensions>
+
+# Bundle custom JVMs
+mac.desktop-vm=zuluFx8
+win.desktop-vm=zulu11
+win.vm32bit=false
+```

--- a/src/main/resources/static/docs/snippets/build-hints-global.md
+++ b/src/main/resources/static/docs/snippets/build-hints-global.md
@@ -1,0 +1,15 @@
+---
+topic: build-hints
+title: Cross-platform build hints
+description: Apply global build toggles that affect analytics, Java version, and resource packaging across targets.
+---
+```properties
+# Prevent Codename One from collecting install metrics
+block_server_registration=false
+
+# Select Codename One server compiler Java version
+java.version=8
+
+# Exclude extra Codename One resources to minimize app size
+noExtraResources=false
+```

--- a/src/main/resources/static/docs/snippets/build-hints-ios-behavior.md
+++ b/src/main/resources/static/docs/snippets/build-hints-ios-behavior.md
@@ -1,0 +1,36 @@
+---
+topic: build-hints
+title: iOS UI and runtime behavior hints
+description: Control keyboard handling, multitasking, theming, and runtime safeguards on iOS.
+---
+```properties
+# Keyboard and application lifecycle
+ios.keyboardOpen=true
+ios.application_exits=false
+
+# Status bar and theme
+ios.statusbar_hidden=false
+ios.themeMode=default
+
+# Orientation and multitasking
+ios.interface_orientation=UIInterfaceOrientationPortrait:UIInterfaceOrientationLandscapeLeft
+ios.multitasking=true
+
+# Rendering pipelines and storage
+ios.newPipeline=true
+ios.newStorageLocation=true
+
+# Visual tweaks
+ios.prerendered_icon=false
+ios.enableBadgeClear=true
+
+# Media behavior
+ios.useAVKit=false
+ios.enableAutoplayVideo=false
+
+# Security options
+ios.detectJailbreak=false
+ios.blockScreenshotsOnEnterBackground=false
+
+ios.headphoneCallback=false
+```

--- a/src/main/resources/static/docs/snippets/build-hints-ios-build.md
+++ b/src/main/resources/static/docs/snippets/build-hints-ios-build.md
@@ -1,0 +1,34 @@
+---
+topic: build-hints
+title: iOS build and distribution hints
+description: Configure architectures, distribution methods, rpmalloc usage, and versioning for iOS builds.
+---
+```properties
+# Architectures and bitcode
+ios.debug.archs=arm64
+ios.release.archs=arm64
+ios.bitcode=false
+
+# Distribution channels
+ios.distributionMethod=app-store
+ios.debug.distributionMethod=ad-hoc
+ios.release.distributionMethod=enterprise
+
+# Team identifiers
+ios.teamId=TEAMID1234
+ios.debug.teamId=DEBUGTEAM123
+ios.release.teamId=RELEASETEAM456
+
+# Project flavor and deployment target
+ios.project_type=ios
+ios.deployment_target=8.0
+ios.rpmalloc=true
+
+# Versioning and release aids
+ios.bundleVersion=1.0.0
+ios.testFlight=false
+ios.generateSplashScreens=false
+
+# Xcode version override
+ios.xcode_version=9.2
+```

--- a/src/main/resources/static/docs/snippets/build-hints-ios-injection.md
+++ b/src/main/resources/static/docs/snippets/build-hints-ios-injection.md
@@ -1,0 +1,33 @@
+---
+topic: build-hints
+title: iOS native code injection hints
+description: Inject Info.plist keys, entitlements, and Objective-C snippets during the iOS build.
+---
+```properties
+# Info.plist customization
+ios.plistInject=<key>NSCameraUsageDescription</key><string>Capture photos</string>
+ios.urlScheme=<string>myapp</string>
+
+# Entitlements
+ios.entitlementsInject=<key>aps-environment</key><string>production</string>
+
+# Objective-C code hooks
+ios.glAppDelegateHeader=#import "MyManager.h"
+ios.glAppDelegateBody=[[MyManager shared] configure];
+ios.beforeFinishLaunching=[MyManager setupBeforeLaunch];
+ios.afterFinishLaunching=[MyManager setupAfterLaunch];
+ios.applicationDidEnterBackground=[MyManager pause];
+ios.viewDidLoad=[self configureLayout];
+
+# Libraries and pods
+ios.add_libs=libsqlite3.dylib;libz.dylib
+ios.pods=AFNetworking ~> 2.6, SwiftyJSON ~> 2.3
+ios.pods.platform=9.0
+ios.objC=true
+
+# Advertising
+ios.googleAdUnitId=ca-app-pub-XXXXXXXXXXXXXXXX/banner
+ios.googleAdUnitIdPadding=16
+
+ios.facebook_permissions=email,user_friends
+```

--- a/src/main/resources/static/docs/snippets/build-hints-ios-permissions.md
+++ b/src/main/resources/static/docs/snippets/build-hints-ios-permissions.md
@@ -1,0 +1,27 @@
+---
+topic: build-hints
+title: iOS entitlements and privacy hints
+description: Declare iOS capabilities, associated domains, and required privacy usage descriptions.
+---
+```properties
+# Associated domains for universal links and keychain
+ios.associatedDomains=applinks:example.com,webcredentials:example.com
+ios.app_groups=group.com.example.shared
+ios.keychainAccessGroup=com.example.app
+
+# Push notification capability
+ios.includePush=true
+
+# URL schemes the app can query
+ios.applicationQueriesSchemes=myapp,myotherapp
+
+# Privacy strings required by iOS 10+
+ios.locationUsageDescription=We use your location to show nearby offers.
+ios.NSCameraUsageDescription=Capture profile photos.
+ios.NSMicrophoneUsageDescription=Record voice notes.
+ios.NSPhotoLibraryAddUsageDescription=Save edited pictures.
+ios.NSPhotoLibraryUsageDescription=Select images to upload.
+ios.NSLocationAlwaysUsageDescription=Provide geofenced alerts.
+ios.NSSpeechRecognitionUsageDescription=Transcribe voice to text.
+ios.NSContactsUsageDescription=Share with friends.
+```

--- a/src/main/resources/static/docs/snippets/build-hints-javascript.md
+++ b/src/main/resources/static/docs/snippets/build-hints-javascript.md
@@ -1,0 +1,20 @@
+---
+topic: build-hints
+title: JavaScript port build hints
+description: Control proxy injection, HTML head customization, and build strictness for the Codename One JavaScript target.
+---
+```properties
+# Proxy configuration for HTTP requests
+javascript.inject_proxy=true
+javascript.proxy.url=https://example.com/proxy
+
+# Inject additional markup in index.html
+javascript.inject.beforeHead=<meta name="viewport" content="width=device-width, initial-scale=1">
+javascript.inject.afterHead=<script src="analytics.js"></script>
+
+# Build output behavior
+javascript.minifying=true
+javascript.sourceFilesCopied=false
+javascript.stopOnErrors=true
+javascript.teavm.version=0.8.1
+```

--- a/src/main/resources/static/docs/snippets/edt-wrap.md
+++ b/src/main/resources/static/docs/snippets/edt-wrap.md
@@ -1,3 +1,8 @@
+---
+topic: threading
+title: Run logic on the Codename One EDT
+description: Use CN.callSerially to ensure UI changes execute on the Codename One event dispatch thread.
+---
 ```java
 import com.codename1.ui.CN;
 

--- a/src/main/resources/static/docs/snippets/rest-get-json.md
+++ b/src/main/resources/static/docs/snippets/rest-get-json.md
@@ -1,3 +1,8 @@
+---
+topic: rest
+title: GET JSON with the Rest API
+description: Fetch JSON asynchronously and handle the response off the EDT before updating the UI.
+---
 ```java
 import com.codename1.io.rest.Rest;
 


### PR DESCRIPTION
## Summary
- call out that build hints must be saved in the root codenameone_settings.properties file with the codename1.arg. prefix for the build servers to apply them
- remove the legacy BlackBerry build hints snippet from the snippet catalog to focus on currently supported targets

## Testing
- mvn -DskipTests package

------
https://chatgpt.com/codex/tasks/task_e_68e7f44d9dd883318ab1e3dead6f2b66