### PR TITLE
Fix checkstyle formatting across services

### DIFF
--- a/src/main/java/com/codename1/server/mcp/dto/AutoFixRequest.java
+++ b/src/main/java/com/codename1/server/mcp/dto/AutoFixRequest.java
@@ -2,9 +2,13 @@ package com.codename1.server.mcp.dto;
 
 import java.util.List;
 
+/** Request payload describing diagnostics to auto-fix for a given source snippet. */
 public record AutoFixRequest(String code, List<LintDiag> diagnostics) {
-    public AutoFixRequest {
-        // SpotBugs: return an immutable snapshot so callers cannot mutate our internal state.
-        diagnostics = diagnostics == null ? null : List.copyOf(diagnostics);
-    }
+  /**
+   * Copies the diagnostics to avoid subsequent external mutations.
+   */
+  public AutoFixRequest {
+    // SpotBugs: return an immutable snapshot so callers cannot mutate our internal state.
+    diagnostics = diagnostics == null ? null : List.copyOf(diagnostics);
+  }
 }

--- a/src/main/java/com/codename1/server/mcp/dto/AutoFixResponse.java
+++ b/src/main/java/com/codename1/server/mcp/dto/AutoFixResponse.java
@@ -2,9 +2,13 @@ package com.codename1.server.mcp.dto;
 
 import java.util.List;
 
+/** Response returned after applying automated fixes to supplied code. */
 public record AutoFixResponse(String patchedCode, List<Patch> patches) {
-    public AutoFixResponse {
-        // SpotBugs: expose a defensive copy of patch metadata to keep responses immutable.
-        patches = patches == null ? null : List.copyOf(patches);
-    }
+  /**
+   * Copies the generated patch list so that the response remains immutable.
+   */
+  public AutoFixResponse {
+    // SpotBugs: expose a defensive copy of patch metadata to keep responses immutable.
+    patches = patches == null ? null : List.copyOf(patches);
+  }
 }

--- a/src/main/java/com/codename1/server/mcp/dto/CompileRequest.java
+++ b/src/main/java/com/codename1/server/mcp/dto/CompileRequest.java
@@ -2,9 +2,13 @@ package com.codename1.server.mcp.dto;
 
 import java.util.List;
 
+/** Request payload describing sources to compile and optional classpath hints. */
 public record CompileRequest(List<FileEntry> files, String classpathHint) {
-    public CompileRequest {
-        // SpotBugs: capture an immutable snapshot of the supplied files list.
-        files = files == null ? null : List.copyOf(files);
-    }
+  /**
+   * Copies the provided files list to keep the request immutable.
+   */
+  public CompileRequest {
+    // SpotBugs: capture an immutable snapshot of the supplied files list.
+    files = files == null ? null : List.copyOf(files);
+  }
 }

--- a/src/main/java/com/codename1/server/mcp/dto/CompileResponse.java
+++ b/src/main/java/com/codename1/server/mcp/dto/CompileResponse.java
@@ -2,9 +2,13 @@ package com.codename1.server.mcp.dto;
 
 import java.util.List;
 
+/** Response returned from the Java compilation endpoint. */
 public record CompileResponse(boolean ok, String javacOutput, List<CompilerError> errors) {
-    public CompileResponse {
-        // SpotBugs: expose compiler errors as an immutable list for consumers.
-        errors = errors == null ? null : List.copyOf(errors);
-    }
+  /**
+   * Copies the compiler error list so that callers cannot mutate the response state.
+   */
+  public CompileResponse {
+    // SpotBugs: expose compiler errors as an immutable list for consumers.
+    errors = errors == null ? null : List.copyOf(errors);
+  }
 }

--- a/src/main/java/com/codename1/server/mcp/dto/CompilerError.java
+++ b/src/main/java/com/codename1/server/mcp/dto/CompilerError.java
@@ -1,3 +1,4 @@
 package com.codename1.server.mcp.dto;
 
+/** Represents a compiler error emitted while building project sources. */
 public record CompilerError(String file, int line, int col, String message) {}

--- a/src/main/java/com/codename1/server/mcp/dto/CssCompileRequest.java
+++ b/src/main/java/com/codename1/server/mcp/dto/CssCompileRequest.java
@@ -2,9 +2,13 @@ package com.codename1.server.mcp.dto;
 
 import java.util.List;
 
+/** Request payload for a CSS compilation run. */
 public record CssCompileRequest(List<FileEntry> files, String inputPath, String outputPath) {
-    public CssCompileRequest {
-        // SpotBugs: prevent callers from mutating the uploaded file list after construction.
-        files = files == null ? null : List.copyOf(files);
-    }
+  /**
+   * Normalizes the list of files to an unmodifiable copy to prevent external mutation.
+   */
+  public CssCompileRequest {
+    // SpotBugs: prevent callers from mutating the uploaded file list after construction.
+    files = files == null ? null : List.copyOf(files);
+  }
 }

--- a/src/main/java/com/codename1/server/mcp/dto/CssCompileResponse.java
+++ b/src/main/java/com/codename1/server/mcp/dto/CssCompileResponse.java
@@ -1,4 +1,4 @@
 package com.codename1.server.mcp.dto;
 
-public record CssCompileResponse(boolean ok, String log) {
-}
+/** Result of compiling Codename One CSS assets. */
+public record CssCompileResponse(boolean ok, String log) {}

--- a/src/main/java/com/codename1/server/mcp/dto/ExplainRequest.java
+++ b/src/main/java/com/codename1/server/mcp/dto/ExplainRequest.java
@@ -1,3 +1,4 @@
 package com.codename1.server.mcp.dto;
 
+/** Request for a textual explanation of a lint rule violation. */
 public record ExplainRequest(String ruleId) {}

--- a/src/main/java/com/codename1/server/mcp/dto/ExplainResponse.java
+++ b/src/main/java/com/codename1/server/mcp/dto/ExplainResponse.java
@@ -1,3 +1,4 @@
 package com.codename1.server.mcp.dto;
 
+/** Explanation text returned for a requested code issue. */
 public record ExplainResponse(String summary, String bad, String good) {}

--- a/src/main/java/com/codename1/server/mcp/dto/FileEntry.java
+++ b/src/main/java/com/codename1/server/mcp/dto/FileEntry.java
@@ -1,3 +1,4 @@
 package com.codename1.server.mcp.dto;
 
+/** Represents a single in-memory file used for compilation or scaffolding. */
 public record FileEntry(String path, String content) {}

--- a/src/main/java/com/codename1/server/mcp/dto/LintDiag.java
+++ b/src/main/java/com/codename1/server/mcp/dto/LintDiag.java
@@ -1,3 +1,4 @@
 package com.codename1.server.mcp.dto;
 
+/** Describes a single lint diagnostic entry. */
 public record LintDiag(String ruleId, String severity, String message, Range range) {}

--- a/src/main/java/com/codename1/server/mcp/dto/LintRequest.java
+++ b/src/main/java/com/codename1/server/mcp/dto/LintRequest.java
@@ -2,12 +2,16 @@ package com.codename1.server.mcp.dto;
 
 import java.util.List;
 
-public record LintRequest(String code,
-                          String language,
-                          List<String> ruleset) {
-    public LintRequest {
-        // SpotBugs: snapshot the requested ruleset so later mutations do not affect lint execution.
-        ruleset = ruleset == null ? null : List.copyOf(ruleset);
-    }
+/** Request payload describing the code to lint and rule configuration. */
+public record LintRequest(
+    String code,
+    String language,
+    List<String> ruleset) {
+  /**
+   * Copies the optional rule set list to guard against external mutation after construction.
+   */
+  public LintRequest {
+    // SpotBugs: snapshot the requested ruleset so later mutations do not affect lint execution.
+    ruleset = ruleset == null ? null : List.copyOf(ruleset);
+  }
 }
-

--- a/src/main/java/com/codename1/server/mcp/dto/LintResponse.java
+++ b/src/main/java/com/codename1/server/mcp/dto/LintResponse.java
@@ -2,10 +2,14 @@ package com.codename1.server.mcp.dto;
 
 import java.util.List;
 
+/** Result produced by the linting pipeline, including diagnostics and quick fixes. */
 public record LintResponse(boolean ok, List<LintDiag> diagnostics, List<QuickFix> quickFixes) {
-    public LintResponse {
-        // SpotBugs: ensure diagnostics and quick fixes remain immutable for callers.
-        diagnostics = diagnostics == null ? null : List.copyOf(diagnostics);
-        quickFixes = quickFixes == null ? null : List.copyOf(quickFixes);
-    }
+  /**
+   * Copies diagnostics and quick fixes to ensure immutability of the response payload.
+   */
+  public LintResponse {
+    // SpotBugs: ensure diagnostics and quick fixes remain immutable for callers.
+    diagnostics = diagnostics == null ? null : List.copyOf(diagnostics);
+    quickFixes = quickFixes == null ? null : List.copyOf(quickFixes);
+  }
 }

--- a/src/main/java/com/codename1/server/mcp/dto/NativeStubRequest.java
+++ b/src/main/java/com/codename1/server/mcp/dto/NativeStubRequest.java
@@ -9,8 +9,11 @@ import java.util.List;
  * be processed.
  */
 public record NativeStubRequest(List<FileEntry> files, String interfaceName) {
-    public NativeStubRequest {
-        // SpotBugs: retain an immutable snapshot of provided source files.
-        files = files == null ? null : List.copyOf(files);
-    }
+  /**
+   * Copies the supplied source files to keep the request immutable after submission.
+   */
+  public NativeStubRequest {
+    // SpotBugs: retain an immutable snapshot of provided source files.
+    files = files == null ? null : List.copyOf(files);
+  }
 }

--- a/src/main/java/com/codename1/server/mcp/dto/NativeStubResponse.java
+++ b/src/main/java/com/codename1/server/mcp/dto/NativeStubResponse.java
@@ -2,12 +2,13 @@ package com.codename1.server.mcp.dto;
 
 import java.util.List;
 
-/**
- * Response payload containing the generated native stub source files.
- */
+/** Response payload containing the generated native stub source files. */
 public record NativeStubResponse(List<FileEntry> files) {
-    public NativeStubResponse {
-        // SpotBugs: respond with an immutable view of generated files.
-        files = files == null ? null : List.copyOf(files);
-    }
+  /**
+   * Normalizes the generated files into an immutable list for safe sharing.
+   */
+  public NativeStubResponse {
+    // SpotBugs: respond with an immutable view of generated files.
+    files = files == null ? null : List.copyOf(files);
+  }
 }

--- a/src/main/java/com/codename1/server/mcp/dto/Patch.java
+++ b/src/main/java/com/codename1/server/mcp/dto/Patch.java
@@ -1,3 +1,4 @@
 package com.codename1.server.mcp.dto;
 
+/** Represents a textual diff patch to apply to user code. */
 public record Patch(String description, String diff) {}

--- a/src/main/java/com/codename1/server/mcp/dto/QuickFix.java
+++ b/src/main/java/com/codename1/server/mcp/dto/QuickFix.java
@@ -1,3 +1,4 @@
 package com.codename1.server.mcp.dto;
 
+/** Suggested remediation for a lint diagnostic. */
 public record QuickFix(String title, Patch patch) {}

--- a/src/main/java/com/codename1/server/mcp/dto/Range.java
+++ b/src/main/java/com/codename1/server/mcp/dto/Range.java
@@ -1,5 +1,7 @@
 package com.codename1.server.mcp.dto;
 
+/** Represents a range within a text document, inclusive of both endpoints. */
 public record Range(Pos start, Pos end) {
-    public record Pos(int line, int col) {}
+  /** Point in a document identified by line and column. */
+  public record Pos(int line, int col) {}
 }

--- a/src/main/java/com/codename1/server/mcp/dto/ScaffoldRequest.java
+++ b/src/main/java/com/codename1/server/mcp/dto/ScaffoldRequest.java
@@ -2,9 +2,13 @@ package com.codename1.server.mcp.dto;
 
 import java.util.List;
 
+/** Request describing the scaffold project to generate. */
 public record ScaffoldRequest(String name, String pkg, List<String> features) {
-    public ScaffoldRequest {
-        // SpotBugs: freeze the feature list to keep scaffold generation deterministic.
-        features = features == null ? null : List.copyOf(features);
-    }
+  /**
+   * Copies the optional feature list so downstream processing remains deterministic.
+   */
+  public ScaffoldRequest {
+    // SpotBugs: freeze the feature list to keep scaffold generation deterministic.
+    features = features == null ? null : List.copyOf(features);
+  }
 }

--- a/src/main/java/com/codename1/server/mcp/dto/ScaffoldResponse.java
+++ b/src/main/java/com/codename1/server/mcp/dto/ScaffoldResponse.java
@@ -2,9 +2,13 @@ package com.codename1.server.mcp.dto;
 
 import java.util.List;
 
+/** Response payload containing the generated scaffold file set. */
 public record ScaffoldResponse(List<FileEntry> files) {
-    public ScaffoldResponse {
-        // SpotBugs: keep scaffold outputs immutable for API consumers.
-        files = files == null ? null : List.copyOf(files);
-    }
+  /**
+   * Copies the generated files so the response remains immutable.
+   */
+  public ScaffoldResponse {
+    // SpotBugs: keep scaffold outputs immutable for API consumers.
+    files = files == null ? null : List.copyOf(files);
+  }
 }

--- a/src/main/java/com/codename1/server/mcp/dto/Snippet.java
+++ b/src/main/java/com/codename1/server/mcp/dto/Snippet.java
@@ -1,3 +1,4 @@
 package com.codename1.server.mcp.dto;
 
+/** Represents a reusable code snippet with optional description metadata. */
 public record Snippet(String title, String description, String code) {}

--- a/src/main/java/com/codename1/server/mcp/dto/SnippetsRequest.java
+++ b/src/main/java/com/codename1/server/mcp/dto/SnippetsRequest.java
@@ -1,3 +1,4 @@
 package com.codename1.server.mcp.dto;
 
+/** Request for curated code snippets on a specific topic. */
 public record SnippetsRequest(String topic) {}

--- a/src/main/java/com/codename1/server/mcp/dto/SnippetsResponse.java
+++ b/src/main/java/com/codename1/server/mcp/dto/SnippetsResponse.java
@@ -2,9 +2,13 @@ package com.codename1.server.mcp.dto;
 
 import java.util.List;
 
+/** Response containing snippets that match a request topic. */
 public record SnippetsResponse(List<Snippet> snippets) {
-    public SnippetsResponse {
-        // SpotBugs: share an immutable view of snippet results.
-        snippets = snippets == null ? null : List.copyOf(snippets);
-    }
+  /**
+   * Copies the snippet list to keep the response immutable.
+   */
+  public SnippetsResponse {
+    // SpotBugs: share an immutable view of snippet results.
+    snippets = snippets == null ? null : List.copyOf(snippets);
+  }
 }

--- a/src/main/java/com/codename1/server/mcp/rules/RulePack.java
+++ b/src/main/java/com/codename1/server/mcp/rules/RulePack.java
@@ -3,26 +3,35 @@ package com.codename1.server.mcp.rules;
 import java.util.List;
 import java.util.regex.Pattern;
 
+/** Central repository of linting rules expressed as regular expressions. */
 public final class RulePack {
-    // Strict deny-list regexes (line-based import + FQNs)
-    public static final List<Pattern> FORBIDDEN = List.of(
-            Pattern.compile("^\\s*import\\s+java\\.awt\\..*;", Pattern.CASE_INSENSITIVE),
-            Pattern.compile("^\\s*import\\s+javax\\.swing\\..*;", Pattern.CASE_INSENSITIVE),
-            Pattern.compile("^\\s*import\\s+javafx\\..*;", Pattern.CASE_INSENSITIVE),
-            Pattern.compile("^\\s*import\\s+java\\.nio\\.file\\..*;", Pattern.CASE_INSENSITIVE),
-            Pattern.compile("^\\s*import\\s+java\\.lang\\.reflect\\..*;", Pattern.CASE_INSENSITIVE),
-            Pattern.compile("^\\s*import\\s+java\\.sql\\..*;", Pattern.CASE_INSENSITIVE)
-    );
+  private RulePack() {}
 
-    public static final List<Pattern> FORBIDDEN_FQNS = List.of(
-            Pattern.compile("java\\.lang\\.Process"),
-            Pattern.compile("Runtime\\.getRuntime\\(\\)\\.exec"),
-            Pattern.compile("java\\.net\\.HttpURLConnection")
-    );
+  // Strict deny-list regexes (line-based import + FQNs)
+  public static final List<Pattern> FORBIDDEN = List.of(
+      Pattern.compile("^\\s*import\\s+java\\.awt\\..*;", Pattern.CASE_INSENSITIVE),
+      Pattern.compile("^\\s*import\\s+javax\\.swing\\..*;", Pattern.CASE_INSENSITIVE),
+      Pattern.compile("^\\s*import\\s+javafx\\..*;", Pattern.CASE_INSENSITIVE),
+      Pattern.compile("^\\s*import\\s+java\\.nio\\.file\\..*;", Pattern.CASE_INSENSITIVE),
+      Pattern.compile("^\\s*import\\s+java\\.lang\\.reflect\\..*;", Pattern.CASE_INSENSITIVE),
+      Pattern.compile("^\\s*import\\s+java\\.sql\\..*;", Pattern.CASE_INSENSITIVE));
 
-    public static final Pattern ABSOLUTE_PATH = Pattern.compile("([A-Za-z]:\\\\|/Users/|/home/|/tmp/)");
-    public static final Pattern UI_MUTATION = Pattern.compile("\\.(add|setText|revalidate|show|setUIID|getStyle\\(\\)\\.set)[\\s\\r\\n]*\\(");
-    public static final Pattern CALLS_SERIAL = Pattern.compile("Display\\.getInstance\\(\\)\\.(callSerially|callSeriallyAndWait)\\s*\\(");
-    public static final Pattern RAW_THREAD = Pattern.compile("new\\s+Thread\\s*\\(");
-    public static final Pattern SLEEP = Pattern.compile("Thread\\.sleep\\s*\\(");
+  public static final List<Pattern> FORBIDDEN_FQNS = List.of(
+      Pattern.compile("java\\.lang\\.Process"),
+      Pattern.compile("Runtime\\.getRuntime\\(\\)\\.exec"),
+      Pattern.compile("java\\.net\\.HttpURLConnection"));
+
+  public static final Pattern ABSOLUTE_PATH =
+      Pattern.compile("([A-Za-z]:\\\\\\\\|/Users/|/home/|/tmp/)");
+
+  public static final Pattern UI_MUTATION =
+      Pattern.compile("\\.(add|setText|revalidate|show|setUIID|getStyle\\(\\)\\.set)[\\s\\r\\n]*\\(");
+
+  public static final Pattern CALLS_SERIAL =
+      Pattern.compile(
+          "Display\\.getInstance\\(\\)\\." + "(callSerially|callSeriallyAndWait)\\s*\\(");
+
+  public static final Pattern RAW_THREAD = Pattern.compile("new\\s+Thread\\s*\\(");
+
+  public static final Pattern SLEEP = Pattern.compile("Thread\\.sleep\\s*\\(");
 }

--- a/src/main/java/com/codename1/server/mcp/service/CssCompileService.java
+++ b/src/main/java/com/codename1/server/mcp/service/CssCompileService.java
@@ -5,10 +5,7 @@ import com.codename1.server.mcp.dto.CssCompileResponse;
 import com.codename1.server.mcp.dto.FileEntry;
 import com.codename1.server.mcp.tools.GlobalExtractor;
 import com.codename1.server.mcp.tools.Jdk8ManagerFromResource;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Service;
-
+import com.codename1.server.mcp.util.OsUtils;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
@@ -17,229 +14,265 @@ import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
 
-import com.codename1.server.mcp.util.OsUtils;
-
+/** Compiles Codename One CSS assets into a binary theme. */
 @Service
 public class CssCompileService {
-    private static final Logger LOG = LoggerFactory.getLogger(CssCompileService.class);
-    private static final Pattern URL_PATTERN = Pattern.compile("url\\(([^)]+)\\)");
-    private static final byte[] STUB_PNG = Base64.getDecoder().decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/YoLYiQAAAAASUVORK5CYII=");
-    private static final byte[] STUB_JPEG = Base64.getDecoder().decode("/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAP//////////////////////////////////////////////////////////////////////////////////////2wBDAf//////////////////////////////////////////////////////////////////////////////////////wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAf/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIQAxAAAAF+AP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAT8Af//EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQIBAT8Af//EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQMBAT8Af//Z");
-    private static final byte[] STUB_SVG = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"1\" height=\"1\"></svg>".getBytes(StandardCharsets.UTF_8);
+  private static final Logger LOG = LoggerFactory.getLogger(CssCompileService.class);
+  private static final Pattern URL_PATTERN = Pattern.compile("url\\(([^)]+)\\)");
+  private static final byte[] STUB_PNG =
+      Base64.getDecoder()
+          .decode("iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/YoLYiQAAAAASUVORK5CYII=");
+  private static final byte[] STUB_JPEG =
+      Base64.getDecoder()
+          .decode(
+              String.join(
+                  "",
+                  "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAP////////////////////////////////////////",
+                  "////////////2wBDAf//////////////////////////////////////////////////////////",
+                  "////////////////////////////////////////////wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAA",
+                  "AAAAAAAAAAAAAAAAAf/xAAUEQEAAAAAAAAAAAAAAAAAAAAA/9oADAMBAAIQAxAAAAF+AP/EABQRAQAAAA",
+                  "AAAAAAAAAAAAAAAAAAD/2gAIAQEAAT8Af//EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQIBAT8Af//EABQRAQA",
+                  "AAAAAAAAAAAAAAAAAAAD/2gAIAQMBAT8Af//Z"));
+  private static final byte[] STUB_SVG =
+      "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"1\" height=\"1\"></svg>"
+          .getBytes(StandardCharsets.UTF_8);
 
-    private final GlobalExtractor extractor;
-    private final Jdk8ManagerFromResource jdk8;
+  private final GlobalExtractor extractor;
+  private final Jdk8ManagerFromResource jdk8;
+  private final Lock fontStubLock = new ReentrantLock();
+  private final AtomicReference<byte[]> fontStub = new AtomicReference<>();
 
-    private final Lock fontStubLock = new ReentrantLock();
-    private final AtomicReference<byte[]> fontStub = new AtomicReference<>();
+  public CssCompileService(GlobalExtractor extractor, Jdk8ManagerFromResource jdk8) {
+    this.extractor = extractor;
+    this.jdk8 = jdk8;
+  }
 
-    public CssCompileService(GlobalExtractor extractor, Jdk8ManagerFromResource jdk8) {
-        this.extractor = extractor;
-        this.jdk8 = jdk8;
+  /**
+   * Compiles the provided CSS request into a Codename One theme resource.
+   */
+  public CssCompileResponse compile(CssCompileRequest request) {
+    Objects.requireNonNull(request, "request");
+    try {
+      Path designerJar = extractor.ensureFile("/cn1libs/designer.jar");
+      Path javaBinary = jdk8.ensureJava8();
+
+      Path workDir = Files.createTempDirectory("cn1css-");
+      Path cssInput = null;
+      List<Path> cssFiles = new ArrayList<>();
+      try {
+        List<FileEntry> files = request.files() == null ? List.of() : List.copyOf(request.files());
+        for (FileEntry entry : files) {
+          Path resolved = safeResolve(workDir, entry.path());
+          Path parent = resolved.getParent();
+          if (parent != null) {
+            Files.createDirectories(parent);
+          }
+          Files.writeString(resolved, entry.content(), StandardCharsets.UTF_8);
+          if (entry.path().equals(request.inputPath())) {
+            cssInput = resolved;
+          }
+          if (entry.path().toLowerCase(Locale.ENGLISH).endsWith(".css")) {
+            cssFiles.add(resolved);
+          }
+        }
+        if (cssFiles.isEmpty()) {
+          throw new IOException("No CSS files supplied for compilation");
+        }
+        if (cssInput == null && !cssFiles.isEmpty()) {
+          cssInput = cssFiles.get(0);
+        }
+        if (cssInput == null) {
+          throw new IOException("No CSS input file provided");
+        }
+
+        String outputName =
+            request.outputPath() != null && !request.outputPath().isBlank()
+                ? request.outputPath()
+                : "theme.res";
+        Path outputFile = safeResolve(workDir, outputName);
+        Files.deleteIfExists(outputFile);
+        Path outputParent = outputFile.getParent();
+        if (outputParent != null) {
+          Files.createDirectories(outputParent);
+        }
+
+        Files.createDirectories(workDir.resolve("target"));
+
+        for (Path cssFile : cssFiles) {
+          ensureCssResources(workDir, cssFile, designerJar);
+        }
+
+        List<String> command = new ArrayList<>();
+        if (OsUtils.isLinux()) {
+          Path xvfb = OsUtils.locateOnPath("xvfb-run");
+          if (xvfb == null) {
+            throw new IOException("xvfb-run command not available on PATH");
+          }
+          command.add(xvfb.toString());
+          command.add("-a");
+        }
+        command.add(javaBinary.toString());
+        command.add("-cp");
+        command.add(designerJar.toString());
+        command.add("com.codename1.designer.css.CN1CSSCLI");
+        command.add("-i");
+        command.add(cssInput.toString());
+        command.add("-o");
+        command.add(outputFile.toString());
+
+        LOG.info("Running CSS compiler: {}", command);
+        ProcessBuilder pb = new ProcessBuilder(command);
+        pb.directory(workDir.toFile());
+        pb.redirectErrorStream(true);
+        Process process = pb.start();
+        String log;
+        try (InputStream in = process.getInputStream()) {
+          log = new String(in.readAllBytes(), StandardCharsets.UTF_8);
+        }
+        int exit = process.waitFor();
+        boolean ok = exit == 0 && Files.exists(outputFile);
+        LOG.info("CSS compile finished with exitCode={} ok={}", exit, ok);
+        return new CssCompileResponse(ok, log);
+      } finally {
+        cleanup(workDir);
+      }
+    } catch (IOException e) {
+      LOG.error("CSS compile failed", e);
+      return new CssCompileResponse(false, e.toString());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOG.error("CSS compile interrupted", e);
+      return new CssCompileResponse(false, e.toString());
     }
+  }
 
-    public CssCompileResponse compile(CssCompileRequest request) {
-        Objects.requireNonNull(request, "request");
-        try {
-            Path designerJar = extractor.ensureFile("/cn1libs/designer.jar");
-            Path javaBinary = jdk8.ensureJava8();
-
-            Path workDir = Files.createTempDirectory("cn1css-");
-            Path cssInput = null;
-            List<Path> cssFiles = new ArrayList<>();
-            try {
-                List<FileEntry> files = request.files() == null ? List.of() : List.copyOf(request.files());
-                for (FileEntry entry : files) {
-                    Path resolved = safeResolve(workDir, entry.path());
-                    Path parent = resolved.getParent();
-                    if (parent != null) {
-                        Files.createDirectories(parent);
-                    }
-                    Files.writeString(resolved, entry.content(), StandardCharsets.UTF_8);
-                    if (entry.path().equals(request.inputPath())) {
-                        cssInput = resolved;
-                    }
-                    if (entry.path().toLowerCase(Locale.ENGLISH).endsWith(".css")) {
-                        cssFiles.add(resolved);
-                    }
-                }
-                if (cssFiles.isEmpty()) {
-                    throw new IOException("No CSS files supplied for compilation");
-                }
-
-                if (cssInput == null) {
-                    cssInput = cssFiles.isEmpty() ? null : cssFiles.get(0);
-                }
-                if (cssInput == null) {
-                    throw new IOException("No CSS input file provided");
-                }
-
-                String outputName = request.outputPath() != null && !request.outputPath().isBlank() ? request.outputPath() : "theme.res";
-                Path outputFile = safeResolve(workDir, outputName);
-                Files.deleteIfExists(outputFile);
-                Path outputParent = outputFile.getParent();
-                if (outputParent != null) {
-                    Files.createDirectories(outputParent);
-                }
-
-                Files.createDirectories(workDir.resolve("target"));
-
-                for (Path cssFile : cssFiles) {
-                    ensureCssResources(workDir, cssFile, designerJar);
-                }
-
-                List<String> command = new ArrayList<>();
-                if (OsUtils.isLinux()) {
-                    Path xvfb = OsUtils.locateOnPath("xvfb-run");
-                    if (xvfb == null) {
-                        throw new IOException("xvfb-run command not available on PATH");
-                    }
-                    command.add(xvfb.toString());
-                    command.add("-a");
-                }
-                command.add(javaBinary.toString());
-                command.add("-cp");
-                command.add(designerJar.toString());
-                command.add("com.codename1.designer.css.CN1CSSCLI");
-                command.add("-i");
-                command.add(cssInput.toString());
-                command.add("-o");
-                command.add(outputFile.toString());
-
-                LOG.info("Running CSS compiler: {}", command);
-                ProcessBuilder pb = new ProcessBuilder(command);
-                pb.directory(workDir.toFile());
-                pb.redirectErrorStream(true);
-                Process process = pb.start();
-                String log;
-                try (InputStream in = process.getInputStream()) {
-                    log = new String(in.readAllBytes(), StandardCharsets.UTF_8);
-                }
-                int exit = process.waitFor();
-                boolean ok = exit == 0 && Files.exists(outputFile);
-                LOG.info("CSS compile finished with exitCode={} ok={}", exit, ok);
-                return new CssCompileResponse(ok, log);
-            } finally {
-                cleanup(workDir);
-            }
-        } catch (IOException e) {
-            LOG.error("CSS compile failed", e);
-            return new CssCompileResponse(false, e.toString());
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            LOG.error("CSS compile interrupted", e);
-            return new CssCompileResponse(false, e.toString());
-        }
+  private Path safeResolve(Path root, String relative) throws IOException {
+    Path resolved = root.resolve(relative).normalize();
+    if (!resolved.startsWith(root)) {
+      throw new IOException("Attempt to escape workspace for path " + relative);
     }
+    return resolved;
+  }
 
-    private Path safeResolve(Path root, String relative) throws IOException {
-        Path resolved = root.resolve(relative).normalize();
-        if (!resolved.startsWith(root)) {
-            throw new IOException("Attempt to escape workspace for path " + relative);
-        }
-        return resolved;
+  private void ensureCssResources(Path workRoot, Path cssFile, Path designerJar) throws IOException {
+    String css = Files.readString(cssFile, StandardCharsets.UTF_8);
+    Matcher matcher = URL_PATTERN.matcher(css);
+    while (matcher.find()) {
+      String raw = matcher.group(1).trim();
+      if (raw.isEmpty()) {
+        continue;
+      }
+      if (raw.startsWith("data:")) {
+        continue;
+      }
+      if (raw.startsWith("#")) {
+        continue;
+      }
+      String cleaned = raw;
+      if ((cleaned.startsWith("\"") && cleaned.endsWith("\""))
+          || (cleaned.startsWith("'") && cleaned.endsWith("'"))) {
+        cleaned = cleaned.substring(1, cleaned.length() - 1);
+      }
+      if (cleaned.startsWith("http://") || cleaned.startsWith("https://")) {
+        continue;
+      }
+      Path cssParent = cssFile.getParent();
+      if (cssParent == null) {
+        cssParent = cssFile.getFileSystem().getPath("");
+      }
+      Path resolved = safeResolve(workRoot, cssParent.resolve(cleaned).toString());
+      if (Files.exists(resolved)) {
+        continue;
+      }
+      Path parent = resolved.getParent();
+      if (parent != null) {
+        Files.createDirectories(parent);
+      }
+      byte[] content = stubContentFor(cleaned, designerJar);
+      Files.write(resolved, content, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
     }
+  }
 
-    private void ensureCssResources(Path workRoot, Path cssFile, Path designerJar) throws IOException {
-        String css = Files.readString(cssFile, StandardCharsets.UTF_8);
-        Matcher matcher = URL_PATTERN.matcher(css);
-        while (matcher.find()) {
-            String raw = matcher.group(1).trim();
-            if (raw.isEmpty()) continue;
-            if (raw.startsWith("data:")) continue;
-            if (raw.startsWith("#")) continue;
-            String cleaned = raw;
-            if ((cleaned.startsWith("\"") && cleaned.endsWith("\"")) || (cleaned.startsWith("'") && cleaned.endsWith("'"))) {
-                cleaned = cleaned.substring(1, cleaned.length() - 1);
-            }
-            if (cleaned.startsWith("http://") || cleaned.startsWith("https://")) continue;
-            Path cssParent = cssFile.getParent();
-            if (cssParent == null) {
-                cssParent = cssFile.getFileSystem().getPath("");
-            }
-            Path resolved = safeResolve(workRoot, cssParent.resolve(cleaned).toString());
-            if (Files.exists(resolved)) continue;
-            Path parent = resolved.getParent();
-            if (parent != null) {
-                Files.createDirectories(parent);
-            }
-            byte[] content = stubContentFor(cleaned, designerJar);
-            Files.write(resolved, content, StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
-        }
+  private byte[] stubContentFor(String path, Path designerJar) throws IOException {
+    String lower = path.toLowerCase(Locale.ENGLISH);
+    if (lower.endsWith(".png") || lower.endsWith(".gif")) {
+      return STUB_PNG;
     }
-
-    private byte[] stubContentFor(String path, Path designerJar) throws IOException {
-        String lower = path.toLowerCase(Locale.ENGLISH);
-        if (lower.endsWith(".png") || lower.endsWith(".gif")) {
-            return STUB_PNG;
-        }
-        if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) {
-            return STUB_JPEG;
-        }
-        if (lower.endsWith(".svg")) {
-            return STUB_SVG;
-        }
-        if (lower.endsWith(".ttf") || lower.endsWith(".otf")) {
-            return loadFontStub(designerJar);
-        }
-        return new byte[0];
+    if (lower.endsWith(".jpg") || lower.endsWith(".jpeg")) {
+      return STUB_JPEG;
     }
+    if (lower.endsWith(".svg")) {
+      return STUB_SVG;
+    }
+    if (lower.endsWith(".ttf") || lower.endsWith(".otf")) {
+      return loadFontStub(designerJar);
+    }
+    return new byte[0];
+  }
 
-    private byte[] loadFontStub(Path designerJar) throws IOException {
-        byte[] cached = fontStub.get();
-        if (cached != null) {
-            return cached;
+  private byte[] loadFontStub(Path designerJar) throws IOException {
+    byte[] cached = fontStub.get();
+    if (cached != null) {
+      return cached;
+    }
+    fontStubLock.lock();
+    try {
+      byte[] existing = fontStub.get();
+      if (existing != null) {
+        return existing;
+      }
+      try (InputStream in = Files.newInputStream(designerJar);
+          ZipInputStream zip = new ZipInputStream(in)) {
+        ZipEntry entry;
+        while ((entry = zip.getNextEntry()) != null) {
+          if (!entry.isDirectory()
+              && entry.getName().equals("com/codename1/impl/javase/Roboto-Regular.ttf")) {
+            byte[] data = zip.readAllBytes();
+            fontStub.set(data);
+            return data;
+          }
         }
-        fontStubLock.lock();
-        try {
-            byte[] existing = fontStub.get();
-            if (existing != null) {
-                return existing;
-            }
-            try (InputStream in = Files.newInputStream(designerJar);
-                 ZipInputStream zip = new ZipInputStream(in)) {
-                ZipEntry entry;
-                while ((entry = zip.getNextEntry()) != null) {
-                    if (!entry.isDirectory() && entry.getName().equals("com/codename1/impl/javase/Roboto-Regular.ttf")) {
-                        byte[] data = zip.readAllBytes();
-                        fontStub.set(data);
-                        return data;
-                    }
+      }
+      throw new IOException("Failed to locate Roboto-Regular.ttf inside designer.jar");
+    } finally {
+      fontStubLock.unlock();
+    }
+  }
+
+  private void cleanup(Path dir) {
+    if (dir == null) {
+      return;
+    }
+    try {
+      Files.walk(dir)
+          .sorted(Comparator.reverseOrder())
+          .forEach(
+              path -> {
+                try {
+                  Files.deleteIfExists(path);
+                } catch (IOException ex) {
+                  // SpotBugs: log cleanup issues instead of silently swallowing them.
+                  LOG.debug("Failed to delete temporary path {}", path, ex);
                 }
-            }
-            throw new IOException("Failed to locate Roboto-Regular.ttf inside designer.jar");
-        } finally {
-            fontStubLock.unlock();
-        }
+              });
+    } catch (IOException ex) {
+      // SpotBugs: deletion failures should be visible during troubleshooting but not fatal.
+      LOG.debug("Failed to walk temporary directory {}", dir, ex);
     }
-
-    private void cleanup(Path dir) {
-        if (dir == null) return;
-        try {
-            Files.walk(dir)
-                    .sorted((a, b) -> b.compareTo(a))
-                    .forEach(path -> {
-                        try {
-                            Files.deleteIfExists(path);
-                        } catch (IOException ex) {
-                            // SpotBugs: log cleanup issues instead of silently swallowing them.
-                            LOG.debug("Failed to delete temporary path {}", path, ex);
-                        }
-                    });
-        } catch (IOException ex) {
-            // SpotBugs: deletion failures should be visible during troubleshooting but not fatal.
-            LOG.debug("Failed to walk temporary directory {}", dir, ex);
-        }
-    }
+  }
 }

--- a/src/main/java/com/codename1/server/mcp/service/ExternalCompileService.java
+++ b/src/main/java/com/codename1/server/mcp/service/ExternalCompileService.java
@@ -5,85 +5,99 @@ import com.codename1.server.mcp.dto.CompileResponse;
 import com.codename1.server.mcp.dto.FileEntry;
 import com.codename1.server.mcp.tools.GlobalExtractor;
 import com.codename1.server.mcp.tools.Jdk8ManagerFromResource;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.nio.file.*;
-import java.util.*;
-
+/** Compiles user-provided Java sources using the embedded Codename One toolchain. */
 @Service
 public class ExternalCompileService {
-    private static final Logger LOG = LoggerFactory.getLogger(ExternalCompileService.class);
-    private final GlobalExtractor extractor;
-    private final Jdk8ManagerFromResource jdk8;
+  private static final Logger LOG = LoggerFactory.getLogger(ExternalCompileService.class);
 
-    public ExternalCompileService(GlobalExtractor extractor, Jdk8ManagerFromResource jdk8) {
-        this.extractor = extractor;
-        this.jdk8 = jdk8;
+  private final GlobalExtractor extractor;
+  private final Jdk8ManagerFromResource jdk8;
+
+  public ExternalCompileService(GlobalExtractor extractor, Jdk8ManagerFromResource jdk8) {
+    this.extractor = extractor;
+    this.jdk8 = jdk8;
+  }
+
+  /**
+   * Compiles the provided Java sources and returns the javac output and status.
+   */
+  public CompileResponse compile(CompileRequest req) {
+    try {
+    List<FileEntry> files = req.files() == null ? List.of() : List.copyOf(req.files());
+    LOG.info("Starting compile request with {} files", files.size());
+
+    // Extract libs once
+    Path cn1 = extractor.ensureFile("/cn1libs/CodenameOne.jar");
+    Path boot = extractor.ensureFile("/cn1libs/CLDC11.jar");
+
+    // Use bundled JDK 8
+    Path javac = jdk8.ensureJavac8();
+    LOG.debug("Resolved javac path: {}", javac);
+
+    // Write sources
+    Path work = Files.createTempDirectory("cn1c-");
+    List<Path> sources = new ArrayList<>();
+    for (var f : files) {
+      Path p = work.resolve(f.path());
+      Path parent = p.getParent();
+      if (parent != null) {
+        Files.createDirectories(parent);
+      }
+      // SpotBugs: guard against files placed at the workspace root which have no parent directory.
+      Files.writeString(p, f.content(), StandardCharsets.UTF_8);
+      sources.add(p);
     }
 
-    public CompileResponse compile(CompileRequest req) {
-        try {
-            List<FileEntry> files = req.files() == null ? List.of() : List.copyOf(req.files());
-            LOG.info("Starting compile request with {} files", files.size());
-            // Extract libs once
-            Path cn1   = extractor.ensureFile("/cn1libs/CodenameOne.jar");
-            Path boot  = extractor.ensureFile("/cn1libs/CLDC11.jar");
-
-            // Use bundled JDK 8
-            Path javac = jdk8.ensureJavac8();
-            LOG.debug("Resolved javac path: {}", javac);
-
-            // Write sources
-            Path work = Files.createTempDirectory("cn1c-");
-            List<Path> sources = new ArrayList<>();
-            for (var f : files) {
-                Path p = work.resolve(f.path());
-                Path parent = p.getParent();
-                if (parent != null) {
-                    Files.createDirectories(parent);
-                }
-                // SpotBugs: guard against files placed at the workspace root which have no parent directory.
-                Files.writeString(p, f.content(), StandardCharsets.UTF_8);
-                sources.add(p);
-            }
-
-            List<String> cmd = new ArrayList<>(List.of(
-                    javac.toString(),
-                    "-source", "8", "-target", "8",
-                    "-Xlint:all",
-                    "-extdirs", "",
-                    "-classpath", cn1.toString()
-            ));
-            if (Files.exists(boot)) {
-                cmd.addAll(List.of("-bootclasspath", boot.toString()));
-            }
-            sources.forEach(s -> cmd.add(s.toString()));
-            LOG.debug("Compile command: {}", cmd);
-
-            ProcessBuilder pb = new ProcessBuilder(cmd);
-            pb.directory(work.toFile());
-            pb.redirectErrorStream(true);
-            Process pr = pb.start();
-            String out;
-            try (InputStream is = pr.getInputStream()) {
-                out = new String(is.readAllBytes(), StandardCharsets.UTF_8);
-            }
-            int code = pr.waitFor();
-            boolean ok = code == 0 && !out.toLowerCase(Locale.ENGLISH).contains("error:");
-            LOG.info("Compile finished with exitCode={} success={}", code, ok);
-            return new CompileResponse(ok, out, List.of());
-        } catch (IOException e) {
-            LOG.error("Compile failed", e);
-            return new CompileResponse(false, e.toString(), List.of());
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            LOG.error("Compile interrupted", e);
-            return new CompileResponse(false, e.toString(), List.of());
-        }
+    List<String> cmd =
+        new ArrayList<>(
+            List.of(
+                javac.toString(),
+                "-source",
+                "8",
+                "-target",
+                "8",
+                "-Xlint:all",
+                "-extdirs",
+                "",
+                "-classpath",
+                cn1.toString()));
+    if (Files.exists(boot)) {
+      cmd.addAll(List.of("-bootclasspath", boot.toString()));
     }
+    sources.forEach(s -> cmd.add(s.toString()));
+    LOG.debug("Compile command: {}", cmd);
+
+    ProcessBuilder pb = new ProcessBuilder(cmd);
+    pb.directory(work.toFile());
+    pb.redirectErrorStream(true);
+    Process pr = pb.start();
+    String out;
+    try (InputStream is = pr.getInputStream()) {
+      out = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+    }
+    int code = pr.waitFor();
+    boolean ok = code == 0 && !out.toLowerCase(Locale.ENGLISH).contains("error:");
+    LOG.info("Compile finished with exitCode={} success={}", code, ok);
+    return new CompileResponse(ok, out, List.of());
+  } catch (IOException e) {
+    LOG.error("Compile failed", e);
+    return new CompileResponse(false, e.toString(), List.of());
+  } catch (InterruptedException e) {
+    Thread.currentThread().interrupt();
+    LOG.error("Compile interrupted", e);
+    return new CompileResponse(false, e.toString(), List.of());
+  }
+  }
 }

--- a/src/main/java/com/codename1/server/mcp/service/LintService.java
+++ b/src/main/java/com/codename1/server/mcp/service/LintService.java
@@ -9,99 +9,143 @@ import com.codename1.server.mcp.rules.RulePack;
 import com.codename1.server.mcp.tools.PatchUtil;
 import com.github.javaparser.StaticJavaParser;
 import com.github.javaparser.ast.CompilationUnit;
+import java.util.ArrayList;
+import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import java.util.ArrayList;
-import java.util.regex.Pattern;
 
+/** Executes linting heuristics against provided source code snippets. */
 @Service
 public class LintService {
-    private static final Logger LOG = LoggerFactory.getLogger(LintService.class);
-    public LintResponse lint(LintRequest req) {
-        String code = req.code();
-        if (code == null) {
-            // SpotBugs: requests may omit the code payload, so treat it as empty to avoid NPEs.
-            code = "";
-        }
-        var diags = new ArrayList<LintDiag>();
-        var fixes = new ArrayList<QuickFix>();
+  private static final Logger LOG = LoggerFactory.getLogger(LintService.class);
+  private static final Range WHOLE_FILE =
+      new Range(new Range.Pos(1, 1), new Range.Pos(1, 1));
 
-        LOG.info("Running lint for language={} codeSize={}", req.language(), code.length());
+  /**
+   * Runs the lint rules on the provided request payload and aggregates diagnostics.
+   */
+  public LintResponse lint(LintRequest req) {
+    String code = req.code();
+    if (code == null) {
+      // SpotBugs: requests may omit the code payload, so treat it as empty to avoid NPEs.
+      code = "";
+    }
+    var diags = new ArrayList<LintDiag>();
+    var fixes = new ArrayList<QuickFix>();
 
-        // 1) Forbidden imports
-        var lines = code.split("\\R");
-        for (int i = 0; i < lines.length; i++) {
-            String ln = lines[i];
-            for (Pattern p : RulePack.FORBIDDEN) {
-                if (p.matcher(ln).find()) {
-                    diags.add(new LintDiag("CN1_FORBIDDEN_IMPORT","error",
-                            "Forbidden import by strict rule.", rng(i, ln)));
-                }
-            }
-        }
+    LOG.info(
+        "Running lint for language={} codeSize={}", req.language(), code.length());
 
-        // 2) Forbidden FQNs
-        for (Pattern p : RulePack.FORBIDDEN_FQNS) {
-            var m = p.matcher(code);
-            if (m.find()) {
-                diags.add(new LintDiag("CN1_FORBIDDEN_API","error",
-                        "Forbidden API: " + m.group(), new Range(new Range.Pos(1,1), new Range.Pos(1,1))));
-            }
+    // 1) Forbidden imports
+    var lines = code.split("\\R");
+    for (int i = 0; i < lines.length; i++) {
+      String ln = lines[i];
+      for (Pattern p : RulePack.FORBIDDEN) {
+        if (p.matcher(ln).find()) {
+          diags.add(
+              new LintDiag(
+                  "CN1_FORBIDDEN_IMPORT",
+                  "error",
+                  "Forbidden import by strict rule.",
+                  rng(i, ln)));
         }
+      }
+    }
 
-        // 3) Absolute paths
-        var m = RulePack.ABSOLUTE_PATH.matcher(code);
-        if (m.find()) {
-            diags.add(new LintDiag("CN1_STORAGE_PATHS","error",
-                    "Use Storage/FileSystemStorage/Preferences instead of absolute paths.",
-                    new Range(new Range.Pos(1,1), new Range.Pos(1,1))));
-        }
+    // 2) Forbidden FQNs
+    for (Pattern p : RulePack.FORBIDDEN_FQNS) {
+      var matcher = p.matcher(code);
+      if (matcher.find()) {
+        diags.add(
+            new LintDiag(
+                "CN1_FORBIDDEN_API",
+                "error",
+                "Forbidden API: " + matcher.group(),
+                WHOLE_FILE));
+      }
+    }
 
-        // 4) EDT rule heuristic
-        boolean hasUiMutation = RulePack.UI_MUTATION.matcher(code).find();
-        boolean wrapped = RulePack.CALLS_SERIAL.matcher(code).find();
-        if (hasUiMutation && !wrapped) {
-            diags.add(new LintDiag("CN1_EDT_RULE","error",
-                    "UI mutations must occur on the EDT. Wrap in Display.getInstance().callSerially(...).",
-                    new Range(new Range.Pos(1,1), new Range.Pos(1,1))));
-            fixes.add(new QuickFix("Wrap UI code in callSerially(...)",
-                    PatchUtil.wrapEdtPatch()));
-        }
+    // 3) Absolute paths
+    var absolute = RulePack.ABSOLUTE_PATH.matcher(code);
+    if (absolute.find()) {
+      diags.add(
+          new LintDiag(
+              "CN1_STORAGE_PATHS",
+              "error",
+              "Use Storage/FileSystemStorage/Preferences instead of absolute paths.",
+              WHOLE_FILE));
+    }
 
-        // 5) Raw threads & sleep (strict => error)
-        if (RulePack.RAW_THREAD.matcher(code).find()) {
-            diags.add(new LintDiag("CN1_RAW_THREADS","error",
-                    "Use CN.execute/NetworkManager instead of raw Thread.", new Range(new Range.Pos(1,1), new Range.Pos(1,1))));
-        }
-        if (RulePack.SLEEP.matcher(code).find()) {
-            diags.add(new LintDiag("CN1_SLEEP_ON_EDT","error",
-                    "Avoid Thread.sleep(); never block the EDT.", new Range(new Range.Pos(1,1), new Range.Pos(1,1))));
-        }
+    // 4) EDT rule heuristic
+    boolean hasUiMutation = RulePack.UI_MUTATION.matcher(code).find();
+    boolean wrapped = RulePack.CALLS_SERIAL.matcher(code).find();
+    if (hasUiMutation && !wrapped) {
+      diags.add(
+          new LintDiag(
+              "CN1_EDT_RULE",
+              "error",
+              "UI mutations must occur on the EDT. Wrap in Display.getInstance().callSerially(...).",
+              WHOLE_FILE));
+      fixes.add(new QuickFix("Wrap UI code in callSerially(...)", PatchUtil.wrapEdtPatch()));
+    }
 
-        // 6) Optional AST pass for imports that escaped regex
-        try {
-            CompilationUnit cu = StaticJavaParser.parse(code);
-            cu.getImports().forEach(imp -> {
+    // 5) Raw threads & sleep (strict => error)
+    if (RulePack.RAW_THREAD.matcher(code).find()) {
+      diags.add(
+          new LintDiag(
+              "CN1_RAW_THREADS",
+              "error",
+              "Use CN.execute/NetworkManager instead of raw Thread.",
+              WHOLE_FILE));
+    }
+    if (RulePack.SLEEP.matcher(code).find()) {
+      diags.add(
+          new LintDiag(
+              "CN1_SLEEP_ON_EDT",
+              "error",
+              "Avoid Thread.sleep(); never block the EDT.",
+              WHOLE_FILE));
+    }
+
+    // 6) Optional AST pass for imports that escaped regex
+    try {
+      CompilationUnit cu = StaticJavaParser.parse(code);
+      cu.getImports()
+          .forEach(
+              imp -> {
                 String q = imp.getNameAsString();
-                if (q.startsWith("java.awt.") || q.startsWith("javax.swing.") ||
-                        q.startsWith("javafx.") || q.startsWith("java.nio.file.") ||
-                        q.startsWith("java.lang.reflect.") || q.startsWith("java.sql.")) {
-                    diags.add(new LintDiag("CN1_FORBIDDEN_IMPORT","error",
-                            "Forbidden import: " + q, new Range(new Range.Pos(1,1), new Range.Pos(1,1))));
+                if (q.startsWith("java.awt.")
+                    || q.startsWith("javax.swing.")
+                    || q.startsWith("javafx.")
+                    || q.startsWith("java.nio.file.")
+                    || q.startsWith("java.lang.reflect.")
+                    || q.startsWith("java.sql.")) {
+                  diags.add(
+                      new LintDiag(
+                          "CN1_FORBIDDEN_IMPORT",
+                          "error",
+                          "Forbidden import: " + q,
+                          WHOLE_FILE));
                 }
-            });
-        } catch (Exception ex) {
-            // SpotBugs: parsing failures are expected on malformed sources; log and continue linting.
-            LOG.debug("AST parse failed, continuing lint", ex);
-        }
-
-        LintResponse response = new LintResponse(diags.isEmpty(), diags, fixes);
-        LOG.info("Lint finished: ok={} diagnostics={} quickFixes={}", response.ok(), response.diagnostics().size(), response.quickFixes().size());
-        return response;
+              });
+    } catch (Exception ex) {
+      // SpotBugs: parsing failures are expected on malformed sources; log and continue linting.
+      LOG.debug("AST parse failed, continuing lint", ex);
     }
 
-    private Range rng(int i, String ln) {
-        return new Range(new Range.Pos(i+1, 1), new Range.Pos(i+1, Math.max(1, ln.length())));
-    }
+    LintResponse response = new LintResponse(diags.isEmpty(), diags, fixes);
+    LOG.info(
+        "Lint finished: ok={} diagnostics={} quickFixes={}",
+        response.ok(),
+        response.diagnostics().size(),
+        response.quickFixes().size());
+    return response;
+  }
+
+  private Range rng(int lineIndex, String lineText) {
+    return new Range(
+        new Range.Pos(lineIndex + 1, 1),
+        new Range.Pos(lineIndex + 1, Math.max(1, lineText.length())));
+  }
 }


### PR DESCRIPTION
## Summary
- add javadoc comments to DTO records and enforce the two-space indentation style
- reorder imports and normalize formatting in RulePack and ExternalCompileService
- refactor LintService and CssCompileService to satisfy checkstyle requirements, including braces and line wrapping

## Testing
- mvn -q -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68e93646fc1c83319095c2f438724b1f