### PR TITLE
Improve MCP STDIO JSON-RPC handling

### DIFF
--- a/src/main/java/com/codename1/server/stdiomcp/StdIoMcpMain.java
+++ b/src/main/java/com/codename1/server/stdiomcp/StdIoMcpMain.java
@@ -42,7 +42,7 @@ public final class StdIoMcpMain {
   private static final String GUIDE_MODE = "cn1_guide";
   private static final List<Map<String, Object>> TOOL_DESCRIPTORS = createToolDescriptors();
   private static final List<String> SUPPORTED_PROTOCOL_VERSIONS =
-      List.of("2025-06-18", "2024-11-05");
+      List.of("2024-11-05");
   private static final String DEFAULT_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS.get(0);
   private static final String SERVER_NAME = "cn1-mcp";
   private static final String SERVER_VERSION = "0.1.0";
@@ -563,13 +563,9 @@ public final class StdIoMcpMain {
       throw new IllegalArgumentException("Unknown prompt: " + name);
     }
 
-    Map<String, Object> content =
-        Map.of(
-            "content",
-            List.of(Map.of("type", "text", "text", output)),
-            "metadata",
-            Map.of());
-    return new RpcRes("2.0", req.id(), content);
+    Map<String, Object> result = new LinkedHashMap<>();
+    result.put("content", List.of(Map.of("type", "text", "text", output)));
+    return new RpcRes("2.0", req.id(), result);
   }
 
   private static Object handleResourcesList(RpcReq req, GuideService guides, ModeState mode) {
@@ -690,8 +686,8 @@ public final class StdIoMcpMain {
         return version;
       }
       LOG.warn(
-          "Unsupported protocolVersion '{}' requested; returning error", version);
-      return null;
+          "Unsupported protocolVersion '{}' requested; falling back to default", version);
+      return DEFAULT_PROTOCOL_VERSION;
     }
     Object versions = params.get("protocolVersions");
     if (versions instanceof List<?> list && !list.isEmpty()) {
@@ -700,8 +696,10 @@ public final class StdIoMcpMain {
           return supported;
         }
       }
-      LOG.warn("No compatible protocolVersions {} requested; returning error", list);
-      return null;
+      LOG.warn(
+          "No compatible protocolVersions {} requested; falling back to default",
+          list);
+      return DEFAULT_PROTOCOL_VERSION;
     }
     return DEFAULT_PROTOCOL_VERSION;
   }

--- a/src/main/java/com/codename1/server/stdiomcp/StdIoMcpMain.java
+++ b/src/main/java/com/codename1/server/stdiomcp/StdIoMcpMain.java
@@ -41,7 +41,8 @@ public final class StdIoMcpMain {
   private static final String DEFAULT_MODE = "default";
   private static final String GUIDE_MODE = "cn1_guide";
   private static final List<Map<String, Object>> TOOL_DESCRIPTORS = createToolDescriptors();
-  private static final List<String> SUPPORTED_PROTOCOL_VERSIONS = List.of("2024-11-05");
+  private static final List<String> SUPPORTED_PROTOCOL_VERSIONS =
+      List.of("2025-06-18", "2024-11-05");
   private static final String DEFAULT_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS.get(0);
   private static final String SERVER_NAME = "cn1-mcp";
   private static final String SERVER_VERSION = "0.1.0";
@@ -425,7 +426,7 @@ public final class StdIoMcpMain {
         if (code == null) {
           throw new IllegalArgumentException("Missing required argument 'code'");
         }
-        int length = code != null ? code.length() : 0;
+        int length = code.length();
         LOG.info("Invoking lint tool for request id={} ({} chars)", req.id(), length);
         toolPayload = lint.lint(new LintRequest(code, "java", List.of()));
       }

--- a/src/main/java/com/codename1/server/stdiomcp/StdIoMcpMain.java
+++ b/src/main/java/com/codename1/server/stdiomcp/StdIoMcpMain.java
@@ -27,7 +27,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.WebApplicationType;
@@ -42,10 +41,11 @@ public final class StdIoMcpMain {
   private static final String DEFAULT_MODE = "default";
   private static final String GUIDE_MODE = "cn1_guide";
   private static final List<Map<String, Object>> TOOL_DESCRIPTORS = createToolDescriptors();
-  private static final String DEFAULT_PROTOCOL_VERSION = "2024-11-05";
-  private static final Set<String> SUPPORTED_PROTOCOL_VERSIONS =
-      Set.of(DEFAULT_PROTOCOL_VERSION);
-  private static final Map<String, Object> SERVER_INFO = Map.of("name", "cn1-mcp", "version", "0.1.0");
+  private static final List<String> SUPPORTED_PROTOCOL_VERSIONS =
+      List.of("2025-06-18", "2024-11-05");
+  private static final String DEFAULT_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS.get(0);
+  private static final Map<String, Object> SERVER_INFO =
+      Map.of("name", "cn1-mcp", "version", "0.1.0");
   private static final Map<String, Object> SERVER_CAPABILITIES =
       Map.of(
           "tools", Map.of("list", Map.of(), "call", Map.of()),
@@ -618,7 +618,8 @@ public final class StdIoMcpMain {
       if (SUPPORTED_PROTOCOL_VERSIONS.contains(version)) {
         return version;
       }
-      LOG.warn("Unsupported protocolVersion '{}' requested, falling back to default", version);
+      LOG.warn("Unsupported protocolVersion '{}' requested, falling back to {}", version,
+          DEFAULT_PROTOCOL_VERSION);
       return DEFAULT_PROTOCOL_VERSION;
     }
     Object versions = params.get("protocolVersions");
@@ -628,7 +629,10 @@ public final class StdIoMcpMain {
           return supported;
         }
       }
-      LOG.warn("Unsupported protocolVersions {} requested, falling back to default", list);
+      LOG.warn(
+          "Unsupported protocolVersions {} requested, falling back to {}",
+          list,
+          DEFAULT_PROTOCOL_VERSION);
       return DEFAULT_PROTOCOL_VERSION;
     }
     return DEFAULT_PROTOCOL_VERSION;

--- a/src/main/java/com/codename1/server/stdiomcp/StdIoMcpMain.java
+++ b/src/main/java/com/codename1/server/stdiomcp/StdIoMcpMain.java
@@ -618,7 +618,8 @@ public final class StdIoMcpMain {
       if (SUPPORTED_PROTOCOL_VERSIONS.contains(version)) {
         return version;
       }
-      return null;
+      LOG.warn("Unsupported protocolVersion '{}' requested, falling back to default", version);
+      return DEFAULT_PROTOCOL_VERSION;
     }
     Object versions = params.get("protocolVersions");
     if (versions instanceof List<?> list && !list.isEmpty()) {
@@ -627,7 +628,8 @@ public final class StdIoMcpMain {
           return supported;
         }
       }
-      return null;
+      LOG.warn("Unsupported protocolVersions {} requested, falling back to default", list);
+      return DEFAULT_PROTOCOL_VERSION;
     }
     return DEFAULT_PROTOCOL_VERSION;
   }

--- a/src/main/java/com/codename1/server/stdiomcp/StdIoMcpMain.java
+++ b/src/main/java/com/codename1/server/stdiomcp/StdIoMcpMain.java
@@ -254,14 +254,19 @@ public final class StdIoMcpMain {
     descriptor.put("description", "Explain a Codename One build or lint error message.");
     descriptor.put(
         "arguments",
-        List.of(
+        Map.of(
+            "type",
+            "object",
+            "properties",
             Map.of(
-                "name",
                 "message",
-                "type",
-                "string",
-                "description",
-                "The compiler, lint, or build error that needs clarification.")));
+                Map.of(
+                    "type",
+                    "string",
+                    "description",
+                    "The compiler, lint, or build error that needs clarification.")),
+            "required",
+            List.of("message")));
     return List.of(Map.copyOf(descriptor));
   }
 
@@ -521,7 +526,7 @@ public final class StdIoMcpMain {
   private static Object handleNotification(RpcReq req) {
     LOG.debug("Received {} notification for id={}", req.method(), req.id());
     if (req.id() != null) {
-      return new RpcRes("2.0", req.id(), Map.of("ok", Boolean.TRUE));
+      return new RpcRes("2.0", req.id(), Map.of());
     }
     return null;
   }
@@ -561,7 +566,9 @@ public final class StdIoMcpMain {
     Map<String, Object> content =
         Map.of(
             "content",
-            List.of(Map.of("type", "text", "text", output)));
+            List.of(Map.of("type", "text", "text", output)),
+            "metadata",
+            Map.of());
     return new RpcRes("2.0", req.id(), content);
   }
 
@@ -682,9 +689,9 @@ public final class StdIoMcpMain {
       if (SUPPORTED_PROTOCOL_VERSIONS.contains(version)) {
         return version;
       }
-      LOG.warn("Unsupported protocolVersion '{}' requested, falling back to {}", version,
-          DEFAULT_PROTOCOL_VERSION);
-      return DEFAULT_PROTOCOL_VERSION;
+      LOG.warn(
+          "Unsupported protocolVersion '{}' requested; returning error", version);
+      return null;
     }
     Object versions = params.get("protocolVersions");
     if (versions instanceof List<?> list && !list.isEmpty()) {
@@ -693,11 +700,8 @@ public final class StdIoMcpMain {
           return supported;
         }
       }
-      LOG.warn(
-          "Unsupported protocolVersions {} requested, falling back to {}",
-          list,
-          DEFAULT_PROTOCOL_VERSION);
-      return DEFAULT_PROTOCOL_VERSION;
+      LOG.warn("No compatible protocolVersions {} requested; returning error", list);
+      return null;
     }
     return DEFAULT_PROTOCOL_VERSION;
   }

--- a/src/main/java/com/codename1/server/stdiomcp/StdIoMcpMain.java
+++ b/src/main/java/com/codename1/server/stdiomcp/StdIoMcpMain.java
@@ -42,7 +42,7 @@ public final class StdIoMcpMain {
   private static final String GUIDE_MODE = "cn1_guide";
   private static final List<Map<String, Object>> TOOL_DESCRIPTORS = createToolDescriptors();
   private static final List<String> SUPPORTED_PROTOCOL_VERSIONS =
-      List.of("2024-11-05");
+      List.of("2025-06-18", "2024-11-05");
   private static final String DEFAULT_PROTOCOL_VERSION = SUPPORTED_PROTOCOL_VERSIONS.get(0);
   private static final String SERVER_NAME = "cn1-mcp";
   private static final String SERVER_VERSION = "0.1.0";


### PR DESCRIPTION
## Summary
- add protocol negotiation metadata and capability declarations to STDIO MCP initialization
- support batch JSON-RPC handling, server/info, ping, prompts, and cancellation notifications
- return structured JSON tool responses and unified error handling across request dispatch

## Testing
- mvn -q -DskipTests compile

------
https://chatgpt.com/codex/tasks/task_e_68eb748445c08331a7fe1b9c4447df01